### PR TITLE
Fix QR login flow timeout and httpOnly sessionid detection

### DIFF
--- a/login.py
+++ b/login.py
@@ -29,14 +29,26 @@ async def main():
     )
 
     page = context.pages[0] if context.pages else await context.new_page()
-    await page.goto(DOUYIN_URL, wait_until="domcontentloaded")
+    # Douyin's heavy JS / bot-detection can stall "domcontentloaded" well past
+    # 30s even though the page is already usable for scanning. Wait only for the
+    # navigation to commit, and don't let a slow load abort the login flow — the
+    # QR UI renders client-side and the cookie poll below gives it 5 minutes.
+    try:
+        await page.goto(DOUYIN_URL, wait_until="commit", timeout=60000)
+    except Exception as e:
+        print(f"[!] 页面加载较慢，继续等待登录: {e}")
 
     print("[*] 等待登录... (登录成功后自动关闭)")
     for _ in range(300):  # 5 min timeout
-        logged_in = await page.evaluate(
-            "() => document.cookie.includes('sessionid')"
-        )
-        if logged_in:
+        # Read the cookie jar instead of document.cookie: sessionid is httpOnly
+        # (invisible to document.cookie) and context.cookies() also survives the
+        # page navigations that destroy the JS execution context mid-poll.
+        try:
+            cookies = await context.cookies()
+        except Exception:
+            await asyncio.sleep(1)
+            continue
+        if any(c.get("name") == "sessionid" for c in cookies):
             print("[+] 登录成功！")
             break
         await asyncio.sleep(1)


### PR DESCRIPTION
## Summary

The QR login flow (`login.py`) could not complete reliably due to two independent issues. Both are fixed here.

### 1. Navigation aborted on slow page loads
Douyin's heavy JS / bot-detection stalls the `domcontentloaded` event well past 30s even when the page is already usable for scanning the QR code. With `wait_until="domcontentloaded"`, `page.goto()` would time out and abort the whole login flow.

**Fix:** switch to `wait_until="commit"` with a 60s timeout, wrapped in `try/except` so a slow load logs a notice and continues — the QR UI renders client-side and the cookie poll already allows 5 minutes.

### 2. `sessionid` never detected → login always "times out"
The `sessionid` cookie is **httpOnly**, so `document.cookie` can never see it. The old check `page.evaluate("() => document.cookie.includes('sessionid')")` returned `false` even after a successful scan, so the poll looped until timeout.

**Fix:** read `context.cookies()` instead, which exposes httpOnly cookies and also survives the page navigations that destroy the JS execution context mid-poll. A `try/except` skips a tick if the context is briefly unavailable during navigation.

## Changes
- `login.py` — `+17 / -5`, single file.

## Testing
Ran `python ./login.py` end-to-end against a real QR scan:
- Output confirmed `[+] 登录成功！`
- Verified the `sessionid` cookie is persisted in the saved browser profile (`data/browser_profile/Default/Cookies`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)