### PR TITLE
feat: Add Qwen3‑ASR support & voice recognition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# The panel route contract compares the served HTML byte-for-byte with this
+# baseline. Keep both files LF-only even on Windows checkouts.
+backend/panel/static/panel.html text eol=lf
+tests/baseline/panel.html text eol=lf

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 
 **导出 & 运维**
 - 导出 [ChatLab](https://github.com/hellodigua/ChatLab) 标准格式（JSON / JSONL），可直接做 AI 聊天分析
+- 可选接入 [Qwen3-ASR Custom Server](https://github.com/MeidoPromotionAssociation/Qwen3-ASR-Custom-Server)，把本地语音转写后写入 JSON / JSONL
 - Web 控制面板：可视化采集 / 导出 / 定时任务 / 远程扫码登录 / 密码保护
 - 定时任务（cron）+ [Server酱](https://sct.ftqq.com) 失败推送到微信
 - Docker 一键部署，数据持久化到 `./data`
@@ -90,6 +91,11 @@ docker compose up -d --build
 | `SCRAPER_INCREMENTAL` | `true` | 采集是否增量 |
 | `SCRAPER_FILTER` | (空) | 过滤指定会话名称 |
 | `SCRAPER_SCHEDULE` | (空) | cron 表达式，如 `0 */6 * * *`（空=不定时） |
+| `QWEN_ASR_URL` | (空) | Qwen3-ASR 服务根地址；留空则不转写语音 |
+| `QWEN_ASR_LANGUAGE` | `Chinese` | 识别语言；设为空字符串则自动检测 |
+| `QWEN_ASR_PROMPT` | (空) | 可选的人名、专有词和领域提示 |
+| `QWEN_ASR_TIMEOUT` | `300` | 单次 ASR HTTP 请求超时秒数 |
+| `QWEN_ASR_BATCH_SIZE` | `10` | 每个批量请求上传的语音文件数；客户端强制上限为 10 |
 
 </details>
 
@@ -200,9 +206,34 @@ python3 extract.py --filter "会话名称" --incremental   # 增量（只取新�
 python3 export.py --filter "会话名称"                    # JSONL（默认）
 python3 export.py --filter "会话名称" --format json      # JSON
 python3 export.py --filter "会话名称" --output data/export.jsonl
+
+# 使用 Qwen3-ASR 转写语音；也可在控制面板中勾选并填写服务地址
+python3 export.py --filter "会话名称" --format json \
+  --asr-url http://127.0.0.1:8000 \
+  --asr-language Chinese \
+  --asr-prompt "人名：小明、小红" \
+  --asr-batch-size 10
 ```
 
-导出内容：文本、表情、图片 URL、语音（base64 嵌入）、分享链接、引用/回复关系。也可在控制面板 **导出** 分区一键操作。
+导出内容：文本、表情、图片 URL、语音标签/转写文本、分享链接、引用/回复关系。也可在控制面板 **导出** 分区一键操作。
+
+启用 ASR 后，导出器会把 `data/media/voice/` 中的原始语音以
+`multipart/form-data` 批量上传到 `POST /v1/audio/transcriptions/batch`，并固定提交
+`convert_audio=true`，由服务端转换抖音 `.mpeg` 音频。成功时消息内容形如：
+
+```text
+[语音转文本] 这是识别出来的文本。
+```
+
+有以下降级规则：
+
+- 控制面板提供独立的 **语音识别** 任务，可以为识别和导出分别选择会话，并实时显示总数、已处理、成功、失败、缺文件、缓存跳过、空结果及当前文件。
+- 识别结果持久化在 SQLite 的 `voice_transcriptions` 表；音频大小或修改时间变化时缓存自动失效。导出始终优先复用缓存，只有勾选“导出时识别尚未缓存的语音”才会现场补识别。
+- 网页可选择是否使用批量接口以及每批 2–10 条；关闭批量后逐条调用单文件接口。客户端在所有入口强制每批最多 10 条。命令行传 `--asr-batch-size 1` 可强制使用单文件接口。
+- 批量请求失败时自动逐文件重试，避免一个坏文件拖累整批。
+- 本地音频缺失、服务不可达、超时、空结果或单条转写失败时，仍正常导出原标签 `[语音 N秒]`。
+- ASR 地址、语言、提示及批量设置会由控制面板持久化到 `data/panel_config.json`；语音内容会发送到所填服务，请只使用可信服务。
+- 当前 Qwen3-ASR 官方输出包含语言、文本和可选时间戳，不包含独立的情绪分类；客户端会兼容自定义服务未来可能返回的 `emotion` 字段。
 
 ## 控制面板
 
@@ -217,7 +248,7 @@ python3 export.py --filter "会话名称" --output data/export.jsonl
 | **概览** | 会话数 / 消息数 / 用户数 |
 | **采集** | 刷新会话列表、增量/全量切换、勾选会话、实时日志 |
 | **定时** | 标准 cron 表达式 + 预设快捷按钮 |
-| **导出** | 选格式和会话一键导出下载、媒体回填（历史图片/视频） |
+| **导出** | 独立 Qwen3-ASR 识别任务与实时进度、缓存复用、批量设置、JSON/JSONL 导出、媒体回填 |
 | **登录** | 远程扫码、Cookie 导入、检查/清除登录态 |
 | **设置** | 访问密码、Server酱 失败通知；4 套主题、中英文切换 |
 

--- a/backend/control_panel.py
+++ b/backend/control_panel.py
@@ -32,6 +32,14 @@ def _save_config(cfg):
     _cfg.save_config(cfg)
 
 
+def _clamp_asr_batch_size(value, minimum: int = 2) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = 10
+    return max(minimum, min(parsed, 10))
+
+
 # ── Scrape job state ──
 _scrape_state = {
     "status": "idle",  # idle | running | completed | failed
@@ -46,6 +54,24 @@ _export_state = {
     "status": "idle",
     "file_path": None,
     "message": "",
+}
+
+# ── Standalone voice recognition state ──
+_voice_recognition_state = {
+    "status": "idle",  # idle | running | completed | failed
+    "phase": "idle",   # scanning | recognizing | completed
+    "total": 0,
+    "done": 0,
+    "ok": 0,
+    "failed": 0,
+    "empty": 0,
+    "missing": 0,
+    "skipped": 0,
+    "current": "",
+    "message": "",
+    "started_at": None,
+    "finished_at": None,
+    "task": None,
 }
 
 # ── Scheduler state ──
@@ -126,6 +152,22 @@ class ExportRequest(BaseModel):
     format: str = "jsonl"
     filter: str = ""
     conversations: list[str] | None = None  # selected nicknames; overrides filter
+    transcribe_voice: bool = False
+    asr_url: str = ""
+    asr_language: str = "Chinese"
+    asr_prompt: str = ""
+    asr_use_batch: bool = True
+    asr_batch_size: int = 10
+
+
+class VoiceRecognitionRequest(BaseModel):
+    conversations: list[str] | None = None
+    asr_url: str = ""
+    asr_language: str = "Chinese"
+    asr_prompt: str = ""
+    use_batch: bool = True
+    batch_size: int = 10
+    force: bool = False
 
 
 class ScheduleRequest(BaseModel):
@@ -149,7 +191,7 @@ class PasswordRequest(BaseModel):
 
 
 class SelectedUpdate(BaseModel):
-    section: str  # "scraper" | "export" | "schedule"
+    section: str  # "scraper" | "export" | "recognition" | "schedule"
     conversations: list[str]
 
 
@@ -431,6 +473,7 @@ async def panel_status():
     conn.close()
 
     cfg = _load_config()
+    env_asr_url = os.environ.get("QWEN_ASR_URL", "").strip()
 
     return {
         "conversations": stats["conversations"],
@@ -449,6 +492,26 @@ async def panel_status():
             "status": _export_state["status"],
             "file_path": _export_state["file_path"],
             "message": _export_state["message"],
+            "asr": {
+                "enabled": bool(cfg.get("asr_enabled", bool(env_asr_url))),
+                "url": cfg.get("asr_url", env_asr_url),
+                "language": cfg.get(
+                    "asr_language",
+                    os.environ.get("QWEN_ASR_LANGUAGE", "Chinese"),
+                ),
+                "prompt": cfg.get(
+                    "asr_prompt", os.environ.get("QWEN_ASR_PROMPT", "")
+                ),
+                "use_batch": bool(cfg.get("asr_use_batch", True)),
+                "batch_size": max(
+                    2, _clamp_asr_batch_size(cfg.get("asr_batch_size", 10)),
+                ),
+            },
+        },
+        "voice_recognition": {
+            key: value
+            for key, value in _voice_recognition_state.items()
+            if key != "task"
         },
         "scheduler": {
             "enabled": _scheduler_state["enabled"],
@@ -765,13 +828,14 @@ async def get_selected():
     return {
         "scraper": cfg.get("scraper_selected", []),
         "export": cfg.get("export_selected", []),
+        "recognition": cfg.get("recognition_selected", []),
         "schedule": cfg.get("schedule_selected", []),
     }
 
 
 @control_router.post("/api/conversations/selected")
 async def set_selected(req: SelectedUpdate):
-    if req.section not in ("scraper", "export", "schedule"):
+    if req.section not in ("scraper", "export", "recognition", "schedule"):
         return JSONResponse({"error": "invalid section"}, status_code=400)
     cfg = _load_config()
     cfg[f"{req.section}_selected"] = list(req.conversations)
@@ -857,23 +921,173 @@ async def _cron_loop(parsed: list, incremental: bool):
         pass
 
 
+def _voice_recognition_payload() -> dict:
+    return {
+        key: value
+        for key, value in _voice_recognition_state.items()
+        if key != "task"
+    }
+
+
+def _update_voice_recognition_progress(progress: dict) -> None:
+    for key in (
+        "phase", "total", "done", "ok", "failed", "empty",
+        "missing", "skipped", "current",
+    ):
+        if key in progress:
+            _voice_recognition_state[key] = progress[key]
+
+    if progress.get("phase") == "scanning":
+        _voice_recognition_state["message"] = "正在扫描本地语音..."
+    elif progress.get("phase") == "recognizing":
+        current = progress.get("current") or ""
+        current_note = f"，当前 {current}" if current else ""
+        _voice_recognition_state["message"] = (
+            f"已处理 {_voice_recognition_state['done']} / "
+            f"{_voice_recognition_state['total']}，成功 "
+            f"{_voice_recognition_state['ok']}，失败 "
+            f"{_voice_recognition_state['failed']}，缺文件 "
+            f"{_voice_recognition_state['missing']}，跳过缓存 "
+            f"{_voice_recognition_state['skipped']}{current_note}"
+        )
+
+
+@control_router.get("/api/voice-recognition/status")
+async def voice_recognition_status():
+    return _voice_recognition_payload()
+
+
+@control_router.post("/api/voice-recognition")
+async def start_voice_recognition(req: VoiceRecognitionRequest):
+    if _voice_recognition_state["status"] == "running":
+        return JSONResponse({"error": "Voice recognition already running"}, status_code=409)
+    if _export_state["status"] == "running":
+        return JSONResponse({"error": "导出进行中，请稍后再识别语音"}, status_code=409)
+    if not req.asr_url.strip():
+        return JSONResponse({"error": "必须填写 ASR 服务地址"}, status_code=400)
+
+    try:
+        from extractor.asr import normalize_server_url
+        asr_url = normalize_server_url(req.asr_url)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+
+    cfg = _load_config()
+    if req.conversations is not None:
+        cfg["recognition_selected"] = list(req.conversations)
+    cfg["asr_url"] = asr_url
+    cfg["asr_language"] = req.asr_language.strip()
+    cfg["asr_prompt"] = req.asr_prompt.strip()
+    cfg["asr_use_batch"] = bool(req.use_batch)
+    cfg["asr_batch_size"] = _clamp_asr_batch_size(req.batch_size)
+    _save_config(cfg)
+
+    _voice_recognition_state.update({
+        "status": "running",
+        "phase": "scanning",
+        "total": 0,
+        "done": 0,
+        "ok": 0,
+        "failed": 0,
+        "empty": 0,
+        "missing": 0,
+        "skipped": 0,
+        "current": "",
+        "message": "正在扫描本地语音...",
+        "started_at": time.time(),
+        "finished_at": None,
+    })
+    task = asyncio.create_task(_run_voice_recognition(req, asr_url))
+    _voice_recognition_state["task"] = task
+    return {"status": "started"}
+
+
+async def _run_voice_recognition(req: VoiceRecognitionRequest, asr_url: str):
+    from functools import partial
+
+    try:
+        from extractor.voice_recognition import recognize_voice_messages
+
+        job = partial(
+            recognize_voice_messages,
+            conversations=req.conversations,
+            asr_url=asr_url,
+            language=req.asr_language.strip() or None,
+            prompt=req.asr_prompt.strip(),
+            timeout=float(os.environ.get("QWEN_ASR_TIMEOUT", "300") or 300),
+            batch_size=(
+                _clamp_asr_batch_size(req.batch_size) if req.use_batch else 1
+            ),
+            force=req.force,
+            progress_cb=_update_voice_recognition_progress,
+        )
+        result = await asyncio.get_running_loop().run_in_executor(None, job)
+        _voice_recognition_state.update(result)
+        _voice_recognition_state["status"] = "completed"
+        _voice_recognition_state["phase"] = "completed"
+        if result["total"]:
+            _voice_recognition_state["message"] = (
+                f"完成：成功 {result['ok']}，失败 {result['failed']}，"
+                f"空结果 {result['empty']}，缺文件 {result['missing']}，"
+                f"跳过缓存 {result['skipped']} / {result['total']}"
+            )
+        else:
+            _voice_recognition_state["message"] = "没有找到语音消息"
+    except Exception as exc:
+        _voice_recognition_state["status"] = "failed"
+        _voice_recognition_state["message"] = f"识别失败: {exc}"
+    finally:
+        _voice_recognition_state["finished_at"] = time.time()
+
+
 @control_router.post("/api/export")
 async def start_export(req: ExportRequest):
     if _export_state["status"] == "running":
         return JSONResponse({"error": "Export already running"}, status_code=409)
+    if _voice_recognition_state["status"] == "running":
+        return JSONResponse({"error": "语音识别进行中，请稍后再导出"}, status_code=409)
+
+    if req.format not in ("json", "jsonl"):
+        return JSONResponse({"error": "format 必须是 json 或 jsonl"}, status_code=400)
+
+    asr_url = ""
+    if req.transcribe_voice:
+        if not req.asr_url.strip():
+            return JSONResponse({"error": "启用语音转写时必须填写 ASR 服务地址"}, status_code=400)
+        try:
+            from extractor.asr import normalize_server_url
+            asr_url = normalize_server_url(req.asr_url)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
 
     _export_state["status"] = "running"
-    _export_state["message"] = "正在导出..."
+    _export_state["message"] = "正在转写语音并导出..." if asr_url else "正在导出..."
 
-    # Persist selection
+    # Persist selection and ASR settings together.
+    cfg = _load_config()
     if req.conversations is not None:
-        cfg = _load_config()
         cfg["export_selected"] = list(req.conversations)
-        _save_config(cfg)
+    cfg["asr_enabled"] = bool(req.transcribe_voice)
+    cfg["asr_url"] = asr_url or req.asr_url.strip()
+    cfg["asr_language"] = req.asr_language.strip()
+    cfg["asr_prompt"] = req.asr_prompt.strip()
+    cfg["asr_use_batch"] = bool(req.asr_use_batch)
+    cfg["asr_batch_size"] = _clamp_asr_batch_size(req.asr_batch_size)
+    _save_config(cfg)
 
     convs = list(req.conversations) if req.conversations else None
     loop = asyncio.get_event_loop()
-    await loop.run_in_executor(None, _do_export, req.format, req.filter, convs)
+    await loop.run_in_executor(
+        None,
+        _do_export,
+        req.format,
+        req.filter,
+        convs,
+        asr_url,
+        req.asr_language.strip(),
+        req.asr_prompt.strip(),
+        1 if not req.asr_use_batch else _clamp_asr_batch_size(req.asr_batch_size),
+    )
     return {
         "status": _export_state["status"],
         "message": _export_state["message"],
@@ -881,7 +1095,15 @@ async def start_export(req: ExportRequest):
     }
 
 
-def _do_export(fmt: str, filter_name: str, conversations: list | None):
+def _do_export(
+    fmt: str,
+    filter_name: str,
+    conversations: list | None,
+    asr_url: str = "",
+    asr_language: str = "Chinese",
+    asr_prompt: str = "",
+    asr_batch_size: int = 10,
+):
     try:
         from extractor.exporter import ChatLabExporter
         import re
@@ -907,13 +1129,27 @@ def _do_export(fmt: str, filter_name: str, conversations: list | None):
                     os.remove(output_path)
                 except Exception:
                     pass
-            exporter = ChatLabExporter(conv_name=targets[0] or None, output_format=fmt)
+            exporter = ChatLabExporter(
+                conv_name=targets[0] or None,
+                output_format=fmt,
+                asr_url=asr_url,
+                asr_language=asr_language,
+                asr_prompt=asr_prompt,
+                asr_batch_size=_clamp_asr_batch_size(asr_batch_size, minimum=1),
+            )
             exporter.export(output_path)
             if not os.path.exists(output_path):
                 raise RuntimeError(f"未找到会话: {targets[0] or '(any)'}")
             _export_state["file_path"] = f"export{ext}"
             size_mb = os.path.getsize(output_path) / (1024 * 1024)
-            _export_state["message"] = f"导出完成 ({size_mb:.1f} MB)"
+            asr_stats = exporter.last_stats.get("asr", {})
+            asr_note = ""
+            if exporter.last_stats.get("voice_transcribed"):
+                asr_note = (
+                    f", 语音转写 {exporter.last_stats.get('voice_transcribed', 0)}"
+                    f"/{exporter.last_stats.get('voice', 0)}"
+                )
+            _export_state["message"] = f"导出完成 ({size_mb:.1f} MB{asr_note})"
         else:
             # Multiple → bundle into a zip
             tmp_dir = os.path.join(data_dir, "export_tmp")
@@ -926,13 +1162,27 @@ def _do_export(fmt: str, filter_name: str, conversations: list | None):
                     pass
 
             produced = []
+            total_voice = 0
+            total_transcribed = 0
             for name in targets:
                 safe = re.sub(r"[^\w\u4e00-\u9fff.-]+", "_", name)[:80] or "conv"
                 path = os.path.join(tmp_dir, f"{safe}{ext}")
                 try:
-                    ChatLabExporter(conv_name=name, output_format=fmt).export(path)
+                    exporter = ChatLabExporter(
+                        conv_name=name,
+                        output_format=fmt,
+                        asr_url=asr_url,
+                        asr_language=asr_language,
+                        asr_prompt=asr_prompt,
+                        asr_batch_size=_clamp_asr_batch_size(asr_batch_size, minimum=1),
+                    )
+                    exporter.export(path)
                     if os.path.exists(path):
                         produced.append((name, path))
+                        total_voice += exporter.last_stats.get("voice", 0)
+                        total_transcribed += exporter.last_stats.get(
+                            "voice_transcribed", 0
+                        )
                 except Exception as e:
                     print(f"[-] 导出 {name} 失败: {e}")
 
@@ -946,7 +1196,14 @@ def _do_export(fmt: str, filter_name: str, conversations: list | None):
 
             _export_state["file_path"] = "export.zip"
             size_mb = os.path.getsize(zip_path) / (1024 * 1024)
-            _export_state["message"] = f"导出完成 ({len(produced)} 个会话, {size_mb:.1f} MB)"
+            asr_note = (
+                f", 语音转写 {total_transcribed}/{total_voice}"
+                if total_transcribed and total_voice
+                else ""
+            )
+            _export_state["message"] = (
+                f"导出完成 ({len(produced)} 个会话, {size_mb:.1f} MB{asr_note})"
+            )
 
         _export_state["status"] = "completed"
     except Exception as e:

--- a/backend/control_panel.py
+++ b/backend/control_panel.py
@@ -32,6 +32,25 @@ def _save_config(cfg):
     _cfg.save_config(cfg)
 
 
+def _utf8_subprocess_env() -> dict:
+    """Force redirected Python child output to UTF-8 on Windows."""
+    env = os.environ.copy()
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["PYTHONUNBUFFERED"] = "1"
+    return env
+
+
+def _read_utf8_or_gbk(path: str) -> str:
+    """Read new UTF-8 logs and legacy Windows GBK/GB18030 logs safely."""
+    with open(path, "rb") as file:
+        raw = file.read()
+    try:
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return raw.decode("gb18030", errors="replace")
+
+
 def _clamp_asr_batch_size(value, minimum: int = 2) -> int:
     try:
         parsed = int(value)
@@ -459,7 +478,10 @@ async def _run_video_backfill():
 @control_router.get("", response_class=HTMLResponse)
 @control_router.get("/", response_class=HTMLResponse)
 async def panel_page():
-    return PANEL_HTML
+    return HTMLResponse(
+        content=PANEL_HTML,
+        headers={"Content-Type": "text/html; charset=utf-8"},
+    )
 
 
 @control_router.get("/api/status")
@@ -570,12 +592,13 @@ async def _run_scrape(cmd):
     _scrape_state["stopped"] = False
     try:
         os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
-        with open(LOG_PATH, "w") as log_file:
+        with open(LOG_PATH, "w", encoding="utf-8", newline="") as log_file:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=log_file,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=os.path.dirname(os.path.dirname(__file__)),
+                env=_utf8_subprocess_env(),
             )
             _scrape_state["process"] = proc
             await proc.wait()
@@ -609,8 +632,7 @@ async def scrape_log(lines: int = 50):
     if not os.path.exists(LOG_PATH):
         return {"log": ""}
     try:
-        with open(LOG_PATH, "r", encoding="utf-8", errors="replace") as f:
-            all_lines = f.readlines()
+        all_lines = _read_utf8_or_gbk(LOG_PATH).splitlines(keepends=True)
         tail = all_lines[-lines:] if len(all_lines) > lines else all_lines
         return {"log": "".join(tail)}
     except Exception:
@@ -622,8 +644,7 @@ async def discover_log(lines: int = 80):
     if not os.path.exists(DISCOVER_LOG_PATH):
         return {"log": ""}
     try:
-        with open(DISCOVER_LOG_PATH, "r", encoding="utf-8", errors="replace") as f:
-            all_lines = f.readlines()
+        all_lines = _read_utf8_or_gbk(DISCOVER_LOG_PATH).splitlines(keepends=True)
         tail = all_lines[-lines:] if len(all_lines) > lines else all_lines
         return {"log": "".join(tail)}
     except Exception:
@@ -753,12 +774,15 @@ async def _run_discover(cmd):
     proc = None
     try:
         os.makedirs(os.path.dirname(DISCOVER_LOG_PATH), exist_ok=True)
-        with open(DISCOVER_LOG_PATH, "w") as log_file:
+        with open(
+            DISCOVER_LOG_PATH, "w", encoding="utf-8", newline=""
+        ) as log_file:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=log_file,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=os.path.dirname(os.path.dirname(__file__)),
+                env=_utf8_subprocess_env(),
             )
             _discover_state["process"] = proc
             await proc.wait()

--- a/backend/database.py
+++ b/backend/database.py
@@ -164,6 +164,11 @@ def get_stats():
 def delete_conversation_messages(conv_id):
     """Delete all messages for a conversation (keep the conversation row)."""
     conn = get_db()
+    conn.execute(
+        "DELETE FROM voice_transcriptions WHERE msg_id IN "
+        "(SELECT msg_id FROM messages WHERE conv_id = ?)",
+        (conv_id,),
+    )
     cur = conn.execute("DELETE FROM messages WHERE conv_id = ?", (conv_id,))
     deleted = cur.rowcount
     conn.execute(
@@ -178,6 +183,11 @@ def delete_conversation_messages(conv_id):
 def delete_conversation(conv_id):
     """Delete a conversation and all its messages."""
     conn = get_db()
+    conn.execute(
+        "DELETE FROM voice_transcriptions WHERE msg_id IN "
+        "(SELECT msg_id FROM messages WHERE conv_id = ?)",
+        (conv_id,),
+    )
     msg_cur = conn.execute("DELETE FROM messages WHERE conv_id = ?", (conv_id,))
     msg_deleted = msg_cur.rowcount
     conv_cur = conn.execute("DELETE FROM conversations WHERE conv_id = ?", (conv_id,))

--- a/backend/main.py
+++ b/backend/main.py
@@ -76,6 +76,19 @@ async def auth_middleware(request: Request, call_next):
     return JSONResponse({"error": "unauthorized"}, status_code=401)
 
 
+@app.middleware("http")
+async def utf8_response_middleware(request: Request, call_next):
+    """Make browser decoding explicit, including on Windows deployments."""
+    response = await call_next(request)
+    content_type = response.headers.get("content-type", "")
+    if (
+        content_type.startswith(("application/json", "text/html"))
+        and "charset=" not in content_type.lower()
+    ):
+        response.headers["content-type"] = f"{content_type}; charset=utf-8"
+    return response
+
+
 from pydantic import BaseModel
 
 

--- a/backend/panel/static/panel.html
+++ b/backend/panel/static/panel.html
@@ -131,12 +131,21 @@ body {
 .row + .row { margin-top: 10px; }
 
 /* ── Form controls ── */
-select, input[type=text], input[type=password] {
+select, input[type=text], input[type=password], input[type=number] {
   background: var(--bg3); border: 1px solid var(--border); color: var(--text);
   padding: 8px 12px; border-radius: 9px; font-size: 13px; outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 select:focus, input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-bg); }
+
+.progress-track {
+  height: 9px; margin-top: 12px; overflow: hidden; border-radius: 999px;
+  background: var(--bg3); border: 1px solid var(--border);
+}
+.progress-fill {
+  height: 100%; width: 0; border-radius: inherit; background: var(--accent);
+  transition: width 0.25s ease;
+}
 
 .btn {
   padding: 8px 18px; border: none; border-radius: 9px; font-size: 13px;
@@ -460,6 +469,54 @@ select:focus, input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px v
     <div class="panel-page" id="page-export">
       <div class="page-head"><h1 data-i18n="exportTitle">导出</h1></div>
   <div class="section">
+    <h2><span data-i18n="voiceRecognitionTitle">语音识别</span> <span class="status status-idle" id="voiceRecognitionStatus" data-i18n="idle">闲置</span></h2>
+    <div class="meta" style="margin-bottom:12px" data-i18n="voiceRecognitionDesc">独立识别所选会话的本地语音并保存结果，导出时会直接复用。</div>
+    <div class="row">
+      <input type="text" id="asrUrlInput" data-i18n-placeholder="asrUrlPlaceholder"
+             placeholder="ASR 服务地址，例如 http://127.0.0.1:8000" style="flex:1;min-width:260px;">
+      <select id="asrLanguage">
+        <option value="Chinese" data-i18n="asrLanguageChinese">中文</option>
+        <option value="" data-i18n="asrLanguageAuto">自动检测语言</option>
+        <option value="English">English</option>
+        <option value="Cantonese">Cantonese</option>
+      </select>
+    </div>
+    <div class="row" style="margin-top:10px;">
+      <input type="text" id="asrPromptInput" data-i18n-placeholder="asrPromptPlaceholder"
+             placeholder="可选：输入人名、专有词等识别提示" style="flex:1;min-width:300px;">
+    </div>
+    <div class="row" style="margin-top:10px;">
+      <label class="conv-check" style="cursor:pointer;padding-left:0;">
+        <input type="checkbox" id="asrUseBatchToggle" onchange="toggleAsrBatchFields()" checked>
+        <span data-i18n="asrUseBatch">使用批量接口</span>
+      </label>
+      <label class="row" style="gap:6px;">
+        <span class="meta" style="margin:0" data-i18n="asrBatchSize">每批数量</span>
+        <input type="number" id="asrBatchSizeInput" value="10" min="2" max="10" step="1" style="width:72px;">
+        <span class="meta" style="margin:0" data-i18n="asrBatchUnit">条（最多 10）</span>
+      </label>
+      <label class="conv-check" style="cursor:pointer;">
+        <input type="checkbox" id="forceRecognitionToggle">
+        <span data-i18n="forceRecognition">重新识别已有结果</span>
+      </label>
+      <button class="btn btn-primary" id="voiceRecognitionBtn" onclick="startVoiceRecognition()" data-i18n="voiceRecognitionBtn">开始识别</button>
+    </div>
+    <div class="conv-list-toolbar" style="margin-top:12px;">
+      <span data-i18n="selectConvsLabel">选择会话:</span>
+      <a href="#" onclick="selectAllConvs('recognition',true);return false;" data-i18n="selectAll">全选</a>
+      <span class="sep">·</span>
+      <a href="#" onclick="selectAllConvs('recognition',false);return false;" data-i18n="selectNone">清空</a>
+      <span class="sep">·</span>
+      <span id="recognitionConvCount">0 / 0</span>
+    </div>
+    <div class="conv-list-box" id="recognitionConvList"></div>
+    <div class="progress-track" id="voiceRecognitionProgressTrack" style="display:none;">
+      <div class="progress-fill" id="voiceRecognitionProgress"></div>
+    </div>
+    <div class="meta" id="voiceRecognitionProgressText"></div>
+    <div class="meta" id="voiceRecognitionMsg"></div>
+  </div>
+  <div class="section">
     <h2><span data-i18n="exportTitle">导出</span> <span class="status status-idle" id="exportStatus" data-i18n="idle">闲置</span></h2>
     <div class="row">
       <select id="exportFormat">
@@ -469,6 +526,13 @@ select:focus, input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px v
       <button class="btn btn-primary" id="exportBtn" onclick="startExport()" data-i18n="exportBtn">导出</button>
       <a class="btn btn-success" id="downloadBtn" style="display:none;text-decoration:none" href="/panel/api/export/download" data-i18n="download">下载</a>
     </div>
+    <div class="row" style="margin-top:12px;">
+      <label class="conv-check" style="cursor:pointer;padding-left:0;">
+        <input type="checkbox" id="transcribeVoiceToggle">
+        <span data-i18n="transcribeVoice">导出时识别尚未缓存的语音</span>
+      </label>
+    </div>
+    <div class="meta" data-i18n="asrDesc">已保存的识别结果始终会写入导出；开启此项后只补识别尚未缓存的语音。</div>
     <div class="conv-list-toolbar" style="margin-top:10px;">
       <span data-i18n="selectConvsLabel">选择会话:</span>
       <a href="#" onclick="selectAllConvs('export',true);return false;" data-i18n="selectAll">全选</a>
@@ -595,7 +659,7 @@ const T = {
     typeAndEnter: '输入文字后回车发送...',
     convListTitle: '会话列表',
     refreshConvList: '刷新会话列表',
-    convListHint: '点击"刷新会话列表"从抖音加载全部会话，然后在下方采集/导出/定时各节勾选需要处理的会话。',
+    convListHint: '点击"刷新会话列表"从抖音加载全部会话，然后在下方采集/识别/导出/定时各节勾选需要处理的会话。',
     scraperTitle: '采集',
     incremental: '增量',
     full: '全量',
@@ -614,6 +678,23 @@ const T = {
     exportTitle: '导出',
     exportBtn: '导出',
     download: '下载',
+    voiceRecognitionTitle: '语音识别',
+    voiceRecognitionDesc: '独立识别所选会话的本地语音并保存结果，导出时会直接复用。未选择会话时处理最近会话。',
+    voiceRecognitionBtn: '开始识别',
+    forceRecognition: '重新识别已有结果',
+    asrUseBatch: '使用批量接口',
+    asrBatchSize: '每批数量',
+    asrBatchUnit: '条（最多 10）',
+    transcribeVoice: '导出时识别尚未缓存的语音',
+    asrUrlPlaceholder: 'ASR 服务地址，例如 http://127.0.0.1:8000',
+    asrLanguageChinese: '中文',
+    asrLanguageAuto: '自动检测语言',
+    asrPromptPlaceholder: '可选：输入人名、专有词等识别提示',
+    asrDesc: '已保存的识别结果始终会写入导出；开启此项后只补识别尚未缓存的语音。',
+    asrUrlRequired: '启用语音转写时必须填写 ASR 服务地址',
+    voiceRecognitionProgress: (done, total, ok, fail, missing, skipped, empty) => `进度 ${done} / ${total} · 成功 ${ok} · 失败 ${fail} · 缺文件 ${missing} · 跳过缓存 ${skipped} · 空结果 ${empty}`,
+    voiceRecognitionStartFailed: '启动语音识别失败',
+    exportRequestFailed: '导出请求失败',
     passwordTitle: '密码',
     passwordDesc: '设置密码以保护聊天查看器和控制面板。',
     enterPassword: '输入密码',
@@ -692,7 +773,7 @@ const T = {
     typeAndEnter: 'Type here and press Enter to send...',
     convListTitle: 'Conversations',
     refreshConvList: 'Refresh conversation list',
-    convListHint: 'Click "Refresh conversation list" to load all conversations from Douyin, then check the ones you want in each section below.',
+    convListHint: 'Click "Refresh conversation list" to load all conversations from Douyin, then choose items independently for scrape, recognition, export, and schedule.',
     scraperTitle: 'Scraper',
     incremental: 'Incremental',
     full: 'Full',
@@ -711,6 +792,23 @@ const T = {
     exportTitle: 'Export',
     exportBtn: 'Export',
     download: 'Download',
+    voiceRecognitionTitle: 'Voice Recognition',
+    voiceRecognitionDesc: 'Recognize and save local voice messages for the selected conversations. Exports reuse saved results. With no selection, the latest conversation is used.',
+    voiceRecognitionBtn: 'Start recognition',
+    forceRecognition: 'Re-recognize saved results',
+    asrUseBatch: 'Use batch endpoint',
+    asrBatchSize: 'Batch size',
+    asrBatchUnit: 'items (max 10)',
+    transcribeVoice: 'Recognize uncached voice during export',
+    asrUrlPlaceholder: 'ASR server URL, e.g. http://127.0.0.1:8000',
+    asrLanguageChinese: 'Chinese',
+    asrLanguageAuto: 'Auto-detect language',
+    asrPromptPlaceholder: 'Optional: names and domain terms to recognize',
+    asrDesc: 'Saved results are always exported. Enable this only to recognize voice messages that are not cached yet.',
+    asrUrlRequired: 'Enter an ASR server URL when voice transcription is enabled',
+    voiceRecognitionProgress: (done, total, ok, fail, missing, skipped, empty) => `Progress ${done} / ${total} · ${ok} ok · ${fail} failed · ${missing} missing · ${skipped} cached · ${empty} empty`,
+    voiceRecognitionStartFailed: 'Failed to start voice recognition',
+    exportRequestFailed: 'Export request failed',
     passwordTitle: 'Password',
     passwordDesc: 'Set a password to protect the chat viewer and panel.',
     enterPassword: 'Enter password',
@@ -831,10 +929,12 @@ let discoveredAt = 0;
 let selectedMap = {           // section -> Set of nicknames
   scraper: new Set(),
   export: new Set(),
+  recognition: new Set(),
   schedule: new Set(),
 };
 let lastDiscoverStatus = 'idle';
 let lastDiscoverMsg = '';
+let asrConfigLoaded = false;
 
 async function loadStatus() {
   try {
@@ -867,6 +967,18 @@ async function loadStatus() {
     document.getElementById('exportBtn').disabled = es.status === 'running';
     document.getElementById('exportMsg').textContent = es.message || '';
     document.getElementById('downloadBtn').style.display = (es.status === 'completed' && es.file_path) ? '' : 'none';
+    if (!asrConfigLoaded) {
+      const asr = es.asr || {};
+      document.getElementById('transcribeVoiceToggle').checked = !!asr.enabled;
+      document.getElementById('asrUrlInput').value = asr.url || '';
+      document.getElementById('asrLanguage').value = asr.language ?? 'Chinese';
+      document.getElementById('asrPromptInput').value = asr.prompt || '';
+      document.getElementById('asrUseBatchToggle').checked = asr.use_batch !== false;
+      document.getElementById('asrBatchSizeInput').value = Math.max(2, Math.min(10, Number(asr.batch_size) || 10));
+      asrConfigLoaded = true;
+      toggleAsrBatchFields();
+    }
+    renderVoiceRecognitionStatus(d.voice_recognition || {});
 
     // Schedule status
     const sch = d.scheduler;
@@ -916,6 +1028,7 @@ async function loadSelections() {
     const d = await r.json();
     selectedMap.scraper = new Set(d.scraper || []);
     selectedMap.export = new Set(d.export || []);
+    selectedMap.recognition = new Set(d.recognition || []);
     selectedMap.schedule = new Set(d.schedule || []);
   } catch {}
 }
@@ -946,7 +1059,7 @@ function renderDiscoverMeta() {
 }
 
 function renderAllConvLists() {
-  ['scrape', 'schedule', 'export'].forEach(prefix => renderConvList(prefix));
+  ['scrape', 'schedule', 'recognition', 'export'].forEach(prefix => renderConvList(prefix));
   renderConvCounts();
 }
 
@@ -987,7 +1100,7 @@ function renderConvList(prefix) {
 }
 
 function renderConvCounts() {
-  ['scrape', 'schedule', 'export'].forEach(prefix => {
+  ['scrape', 'schedule', 'recognition', 'export'].forEach(prefix => {
     const el = document.getElementById(prefix + 'ConvCount');
     if (!el) return;
     el.textContent = t('convsCount', selectedMap[sectionKey(prefix)].size, discoveredConvs.length);
@@ -1148,19 +1261,125 @@ async function updateSchedule() {
   loadStatus();
 }
 
+function toggleAsrBatchFields() {
+  document.getElementById('asrBatchSizeInput').disabled = !document.getElementById('asrUseBatchToggle').checked;
+}
+
+function getAsrBatchSize() {
+  const input = document.getElementById('asrBatchSizeInput');
+  const value = Math.max(2, Math.min(10, Number.parseInt(input.value, 10) || 10));
+  input.value = value;
+  return value;
+}
+
+let voiceRecognitionPollTimer = null;
+
+function renderVoiceRecognitionStatus(d) {
+  const status = d.status || 'idle';
+  setStatusEl(document.getElementById('voiceRecognitionStatus'), status);
+  const running = status === 'running';
+  const exportRunning = document.getElementById('exportStatus').classList.contains('status-running');
+  document.getElementById('voiceRecognitionBtn').disabled = running || exportRunning;
+  if (running) document.getElementById('exportBtn').disabled = true;
+  const total = Number(d.total) || 0;
+  const done = Number(d.done) || 0;
+  const showProgress = status !== 'idle' || total > 0;
+  document.getElementById('voiceRecognitionProgressTrack').style.display = showProgress ? '' : 'none';
+  document.getElementById('voiceRecognitionProgress').style.width = (total ? Math.min(100, done * 100 / total) : 0) + '%';
+  setDynText(
+    document.getElementById('voiceRecognitionProgressText'),
+    showProgress ? t('voiceRecognitionProgress', done, total, d.ok || 0, d.failed || 0, d.missing || 0, d.skipped || 0, d.empty || 0) : ''
+  );
+  setDynText(document.getElementById('voiceRecognitionMsg'), d.message || '');
+  if (running && !voiceRecognitionPollTimer) {
+    voiceRecognitionPollTimer = setInterval(pollVoiceRecognition, 1000);
+  } else if (!running && voiceRecognitionPollTimer) {
+    clearInterval(voiceRecognitionPollTimer);
+    voiceRecognitionPollTimer = null;
+  }
+}
+
+async function pollVoiceRecognition() {
+  try {
+    const r = await fetch('/panel/api/voice-recognition/status');
+    const d = await r.json();
+    renderVoiceRecognitionStatus(d);
+  } catch (e) { console.error('Voice recognition status failed:', e); }
+}
+
+async function startVoiceRecognition() {
+  const asr_url = document.getElementById('asrUrlInput').value.trim();
+  if (!asr_url) {
+    setDynText(document.getElementById('voiceRecognitionMsg'), t('asrUrlRequired'));
+    document.getElementById('asrUrlInput').focus();
+    return;
+  }
+  const payload = {
+    conversations: [...selectedMap.recognition],
+    asr_url,
+    asr_language: document.getElementById('asrLanguage').value,
+    asr_prompt: document.getElementById('asrPromptInput').value.trim(),
+    use_batch: document.getElementById('asrUseBatchToggle').checked,
+    batch_size: getAsrBatchSize(),
+    force: document.getElementById('forceRecognitionToggle').checked,
+  };
+  document.getElementById('voiceRecognitionBtn').disabled = true;
+  setStatusEl(document.getElementById('voiceRecognitionStatus'), 'running');
+  try {
+    const r = await fetch('/panel/api/voice-recognition', {
+      method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload),
+    });
+    const d = await r.json();
+    if (!r.ok || d.error) throw new Error(d.error || t('voiceRecognitionStartFailed'));
+    await pollVoiceRecognition();
+  } catch (e) {
+    setStatusEl(document.getElementById('voiceRecognitionStatus'), 'failed');
+    setDynText(document.getElementById('voiceRecognitionMsg'), t('voiceRecognitionStartFailed') + ': ' + e.message);
+    document.getElementById('voiceRecognitionBtn').disabled = false;
+  }
+}
+
 async function startExport() {
   const format = document.getElementById('exportFormat').value;
   const conversations = [...selectedMap.export];
+  const transcribe_voice = document.getElementById('transcribeVoiceToggle').checked;
+  const asr_url = document.getElementById('asrUrlInput').value.trim();
+  const asr_language = document.getElementById('asrLanguage').value;
+  const asr_prompt = document.getElementById('asrPromptInput').value.trim();
+  const asr_use_batch = document.getElementById('asrUseBatchToggle').checked;
+  const asr_batch_size = getAsrBatchSize();
+  if (transcribe_voice && !asr_url) {
+    document.getElementById('exportMsg').textContent = t('asrUrlRequired');
+    document.getElementById('asrUrlInput').focus();
+    return;
+  }
   if (conversations.length > 1 && !confirm(t('confirmMultiExport', conversations.length))) {
     return;
   }
   document.getElementById('exportBtn').disabled = true;
   setStatusEl(document.getElementById('exportStatus'), 'running');
-  await fetch('/panel/api/export', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({ format, conversations }),
-  });
+  try {
+    const r = await fetch('/panel/api/export', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        format, conversations, transcribe_voice, asr_url, asr_language, asr_prompt,
+        asr_use_batch, asr_batch_size,
+      }),
+    });
+    const d = await r.json();
+    if (!r.ok || d.error) {
+      setStatusEl(document.getElementById('exportStatus'), 'failed');
+      document.getElementById('exportMsg').textContent = d.error || t('exportRequestFailed');
+      document.getElementById('exportBtn').disabled = false;
+      return;
+    }
+  } catch (e) {
+    setStatusEl(document.getElementById('exportStatus'), 'failed');
+    document.getElementById('exportMsg').textContent = t('exportRequestFailed') + ': ' + e;
+    document.getElementById('exportBtn').disabled = false;
+    return;
+  }
   loadStatus();
 }
 
@@ -1544,6 +1763,7 @@ async function panelAuthCheck() {
       loadPasswordStatus();
       loadNotifyStatus();
       loadDownloadImages();
+      pollVoiceRecognition();
       pollBackfill();
       loadVideoPending();
       pollVideoBackfill();

--- a/common/db.py
+++ b/common/db.py
@@ -69,6 +69,18 @@ def init_db():
             FOREIGN KEY (conv_id) REFERENCES conversations(conv_id)
         );
 
+        CREATE TABLE IF NOT EXISTS voice_transcriptions (
+            msg_id TEXT PRIMARY KEY,
+            text TEXT NOT NULL,
+            language TEXT,
+            model TEXT,
+            emotion TEXT,
+            source_size INTEGER,
+            source_mtime_ns INTEGER,
+            asr_url TEXT,
+            transcribed_at INTEGER NOT NULL DEFAULT 0
+        );
+
         CREATE INDEX IF NOT EXISTS idx_messages_conv ON messages(conv_id, timestamp);
         CREATE INDEX IF NOT EXISTS idx_messages_seq ON messages(conv_id, seq);
         CREATE INDEX IF NOT EXISTS idx_messages_content ON messages(content);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - SCRAPER_INCREMENTAL=true    # incremental by default
       - SCRAPER_FILTER=             # empty = all conversations
       - SCRAPER_SCHEDULE=           # cron expr, e.g. "0 */6 * * *" (empty = no schedule)
+      - QWEN_ASR_URL=${QWEN_ASR_URL:-}                 # optional, e.g. http://qwen3-asr:8000
+      - QWEN_ASR_LANGUAGE=${QWEN_ASR_LANGUAGE-Chinese}  # empty = auto detect
+      - QWEN_ASR_PROMPT=${QWEN_ASR_PROMPT:-}           # optional names/domain terms
+      - QWEN_ASR_TIMEOUT=${QWEN_ASR_TIMEOUT:-300}       # seconds per request
+      - QWEN_ASR_BATCH_SIZE=${QWEN_ASR_BATCH_SIZE:-10}  # max 10 uploaded files per batch
     restart: unless-stopped
     networks:
       - web-internal

--- a/export.py
+++ b/export.py
@@ -6,6 +6,17 @@
   python3 export.py --filter "会话名称"           # 导出指定会话
   python3 export.py --filter "会话名称" --format json  # 导出为 JSON
   python3 export.py --output data/my_export.jsonl      # 指定输出路径
+  python3 export.py --asr-url http://127.0.0.1:8000    # 导出时转写语音
+
+ASR 可选参数:
+  --asr-url URL             Qwen3-ASR Custom Server 根地址
+  --asr-language LANGUAGE   语言名称/代码；auto 表示自动检测（默认 Chinese）
+  --asr-prompt TEXT         人名、领域词等识别提示
+  --asr-timeout SECONDS     单次请求超时（默认 300）
+  --asr-batch-size N        每批文件数（默认/上限 10；设为 1 使用单文件接口）
+
+也可使用 QWEN_ASR_URL、QWEN_ASR_LANGUAGE、QWEN_ASR_PROMPT、
+QWEN_ASR_TIMEOUT、QWEN_ASR_BATCH_SIZE 环境变量。
 """
 import os
 import sys
@@ -19,6 +30,11 @@ def main():
     name_filter = None
     output_format = "jsonl"
     output_path = None
+    asr_url = None
+    asr_language = None
+    asr_prompt = None
+    asr_timeout = None
+    asr_batch_size = None
 
     args = sys.argv[1:]
     i = 0
@@ -32,6 +48,22 @@ def main():
         elif args[i] == "--output" and i + 1 < len(args):
             output_path = args[i + 1]
             i += 2
+        elif args[i] == "--asr-url" and i + 1 < len(args):
+            asr_url = args[i + 1]
+            i += 2
+        elif args[i] == "--asr-language" and i + 1 < len(args):
+            value = args[i + 1]
+            asr_language = "" if value.lower() in ("auto", "none", "detect") else value
+            i += 2
+        elif args[i] == "--asr-prompt" and i + 1 < len(args):
+            asr_prompt = args[i + 1]
+            i += 2
+        elif args[i] == "--asr-timeout" and i + 1 < len(args):
+            asr_timeout = args[i + 1]
+            i += 2
+        elif args[i] == "--asr-batch-size" and i + 1 < len(args):
+            asr_batch_size = args[i + 1]
+            i += 2
         elif args[i] in ("-h", "--help"):
             print(__doc__.strip())
             return
@@ -41,7 +73,15 @@ def main():
     ext = ".json" if output_format == "json" else ".jsonl"
     output_path = output_path or os.path.join("data", f"export{ext}")
 
-    exporter = ChatLabExporter(conv_name=name_filter, output_format=output_format)
+    exporter = ChatLabExporter(
+        conv_name=name_filter,
+        output_format=output_format,
+        asr_url=asr_url,
+        asr_language=asr_language,
+        asr_prompt=asr_prompt,
+        asr_timeout=asr_timeout,
+        asr_batch_size=asr_batch_size,
+    )
     exporter.export(output_path)
 
 

--- a/extract.py
+++ b/extract.py
@@ -16,6 +16,11 @@ def _parse_args():
         "download_images": "--download-images" in sys.argv,
         "output_format": "jsonl",
         "output_path": None,
+        "asr_url": None,
+        "asr_language": None,
+        "asr_prompt": None,
+        "asr_timeout": None,
+        "asr_batch_size": None,
     }
 
     if "--discover" in sys.argv:
@@ -32,6 +37,17 @@ def _parse_args():
             args["output_format"] = sys.argv[i + 1]
         elif arg == "--output" and i < len(sys.argv) - 1:
             args["output_path"] = sys.argv[i + 1]
+        elif arg == "--asr-url" and i < len(sys.argv) - 1:
+            args["asr_url"] = sys.argv[i + 1]
+        elif arg == "--asr-language" and i < len(sys.argv) - 1:
+            value = sys.argv[i + 1]
+            args["asr_language"] = "" if value.lower() in ("auto", "none", "detect") else value
+        elif arg == "--asr-prompt" and i < len(sys.argv) - 1:
+            args["asr_prompt"] = sys.argv[i + 1]
+        elif arg == "--asr-timeout" and i < len(sys.argv) - 1:
+            args["asr_timeout"] = sys.argv[i + 1]
+        elif arg == "--asr-batch-size" and i < len(sys.argv) - 1:
+            args["asr_batch_size"] = sys.argv[i + 1]
 
     return args
 
@@ -47,6 +63,11 @@ def run_export(args):
     exporter = ChatLabExporter(
         conv_name=args["name_filter"],
         output_format=fmt,
+        asr_url=args["asr_url"],
+        asr_language=args["asr_language"],
+        asr_prompt=args["asr_prompt"],
+        asr_timeout=args["asr_timeout"],
+        asr_batch_size=args["asr_batch_size"],
     )
     exporter.export(output_path)
 

--- a/extractor/asr.py
+++ b/extractor/asr.py
@@ -1,0 +1,328 @@
+"""Client for the Qwen3-ASR Custom Server HTTP API.
+
+The server intentionally resembles OpenAI's audio transcription path, but its
+multipart fields and JSON response are project-specific.  Keeping that
+contract in one small module makes the exporter easy to test and prevents HTTP
+details from leaking into the ChatLab transformation code.
+"""
+from __future__ import annotations
+
+from contextlib import ExitStack
+from dataclasses import dataclass
+import json
+import mimetypes
+import os
+from typing import Callable, Iterable
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+
+_SINGLE_PATH = "/v1/audio/transcriptions"
+_BATCH_PATH = "/v1/audio/transcriptions/batch"
+_KNOWN_ENDPOINTS = (_BATCH_PATH, _SINGLE_PATH, "/healthz")
+
+
+class QwenASRError(RuntimeError):
+    """Raised when the ASR server cannot produce a valid transcription."""
+
+
+@dataclass(frozen=True)
+class ASRResult:
+    """Normalized subset of a Qwen3-ASR transcription response."""
+
+    text: str
+    language: str | None = None
+    model: str | None = None
+    # Qwen3-ASR itself currently does not expose emotion classification.  Keep
+    # this optional field so a future/custom server extension can be consumed
+    # without another exporter format change.
+    emotion: str | None = None
+
+
+def normalize_server_url(value: str) -> str:
+    """Return a validated base URL, accepting a pasted full API endpoint too."""
+    raw = (value or "").strip()
+    parsed = urlsplit(raw)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError("ASR 服务地址必须是有效的 http:// 或 https:// URL")
+
+    path = parsed.path.rstrip("/")
+    for endpoint in _KNOWN_ENDPOINTS:
+        if path.endswith(endpoint):
+            path = path[: -len(endpoint)].rstrip("/")
+            break
+
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def _response_error(response: httpx.Response) -> str:
+    """Extract FastAPI's useful error detail without dumping an HTML page."""
+    detail = None
+    try:
+        payload = response.json()
+        if isinstance(payload, dict):
+            detail = payload.get("detail") or payload.get("error")
+    except (ValueError, json.JSONDecodeError):
+        pass
+
+    if isinstance(detail, (dict, list)):
+        detail = json.dumps(detail, ensure_ascii=False)
+    if not detail:
+        detail = (response.text or response.reason_phrase or "未知错误").strip()
+    detail = str(detail).replace("\r", " ").replace("\n", " ")[:500]
+    return f"ASR 服务返回 HTTP {response.status_code}: {detail}"
+
+
+def _optional_text(payload: dict, *names: str) -> str | None:
+    for name in names:
+        value = payload.get(name)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return None
+
+
+class QwenASRClient:
+    """Synchronous client used by the synchronous export pipeline.
+
+    Files are sent to the batch endpoint in bounded groups.  If a batch is
+    rejected (for example, one file is corrupt), it is retried file-by-file so
+    one bad voice message does not discard all other transcriptions.
+    """
+
+    def __init__(
+        self,
+        server_url: str,
+        *,
+        language: str | None = "Chinese",
+        prompt: str = "",
+        timeout: float = 300,
+        batch_size: int = 10,
+        transport: httpx.BaseTransport | None = None,
+        trust_env: bool = False,
+    ):
+        self.server_url = normalize_server_url(server_url)
+        self.language = (language or "").strip() or None
+        self.prompt = (prompt or "").strip()
+        if timeout <= 0:
+            raise ValueError("ASR 超时时间必须大于 0 秒")
+        if batch_size <= 0:
+            raise ValueError("ASR 批量大小必须大于 0")
+        self.timeout = float(timeout)
+        self.batch_size = min(int(batch_size), 10)
+        self._client = httpx.Client(
+            base_url=self.server_url.rstrip("/") + "/",
+            timeout=httpx.Timeout(self.timeout, connect=min(10.0, self.timeout)),
+            follow_redirects=True,
+            headers={"User-Agent": "douyin-chat-export/qwen3-asr"},
+            transport=transport,
+            # ASR servers are commonly reached over localhost, Docker DNS, a
+            # LAN, or a private overlay network.  System HTTP_PROXY settings
+            # can turn those otherwise valid requests into proxy-side 502s and
+            # may disclose private audio to an unintended proxy.
+            trust_env=trust_env,
+        )
+
+    def __enter__(self) -> "QwenASRClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def health(self) -> dict:
+        """Check that the service and model are actually ready."""
+        try:
+            response = self._client.get("healthz")
+        except httpx.TimeoutException as exc:
+            raise QwenASRError(f"ASR 健康检查超时（{self.timeout:g} 秒）") from exc
+        except httpx.RequestError as exc:
+            raise QwenASRError(f"无法连接 ASR 服务: {exc}") from exc
+
+        if response.status_code >= 400:
+            raise QwenASRError(_response_error(response))
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise QwenASRError("ASR 健康检查未返回 JSON") from exc
+        if not isinstance(payload, dict) or payload.get("ok") is not True:
+            raise QwenASRError("ASR 服务尚未就绪")
+        return payload
+
+    def transcribe_files(
+        self,
+        file_paths: Iterable[str],
+        progress_cb: Callable[[dict], None] | None = None,
+    ) -> tuple[dict[str, ASRResult], dict[str, str]]:
+        """Transcribe files and return ``(successful_results, errors)``.
+
+        Both dictionaries use normalized absolute file paths as keys. Missing
+        files are reported without making an HTTP request.
+        """
+        ordered_paths: list[str] = []
+        seen: set[str] = set()
+        errors: dict[str, str] = {}
+        missing_paths: list[str] = []
+        completed = 0
+
+        def report(
+            path: str,
+            *,
+            result: ASRResult | None = None,
+            error: str | None = None,
+        ) -> None:
+            nonlocal completed
+            completed += 1
+            if not progress_cb:
+                return
+            try:
+                progress_cb({
+                    "path": path,
+                    "result": result,
+                    "error": error,
+                    "done": completed,
+                    "total": len(seen),
+                })
+            except Exception:
+                # UI progress must never be able to break transcription.
+                pass
+
+        for raw_path in file_paths:
+            path = os.path.abspath(os.fspath(raw_path))
+            if path in seen:
+                continue
+            seen.add(path)
+            if not os.path.isfile(path):
+                errors[path] = "本地语音文件不存在"
+                missing_paths.append(path)
+                continue
+            ordered_paths.append(path)
+
+        for path in missing_paths:
+            report(path, error=errors[path])
+
+        results: dict[str, ASRResult] = {}
+        if not ordered_paths:
+            return results, errors
+
+        try:
+            self.health()
+        except QwenASRError as exc:
+            for path in ordered_paths:
+                errors[path] = str(exc)
+                report(path, error=errors[path])
+            return results, errors
+
+        batch_available = self.batch_size > 1
+        for start in range(0, len(ordered_paths), self.batch_size):
+            batch = ordered_paths[start : start + self.batch_size]
+            if batch_available and len(batch) > 1:
+                try:
+                    batch_results = self._transcribe_batch(batch)
+                    results.update(batch_results)
+                    for path in batch:
+                        report(path, result=batch_results[path])
+                    continue
+                except QwenASRError:
+                    # If the deployment does not support/has broken the batch
+                    # endpoint, do not pay the same failure latency again for
+                    # every later group in a large export.
+                    batch_available = False
+
+            # Salvage valid files when a multi-file request failed because of
+            # one malformed upload/response item, or use the single endpoint
+            # directly when this group contains one file.
+            for path in batch:
+                try:
+                    results[path] = self._transcribe_one(path)
+                    report(path, result=results[path])
+                except QwenASRError as exc:
+                    errors[path] = str(exc)
+                    report(path, error=errors[path])
+
+        return results, errors
+
+    def _form_data(self) -> dict[str, str]:
+        # Douyin voice files are commonly AAC in an MP4 container despite the
+        # *.mpeg filename. Ask the custom server to normalize the upload before
+        # soundfile/Transformers attempts to decode it.
+        data: dict[str, str] = {"convert_audio": "true"}
+        if self.language:
+            data["language"] = self.language
+        if self.prompt:
+            data["prompt"] = self.prompt
+        return data
+
+    @staticmethod
+    def _file_tuple(path: str, handle) -> tuple[str, object, str]:
+        mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
+        return os.path.basename(path), handle, mime
+
+    def _request(self, path: str, *, files, data: dict[str, str]) -> httpx.Response:
+        try:
+            response = self._client.post(path.lstrip("/"), files=files, data=data)
+        except httpx.TimeoutException as exc:
+            raise QwenASRError(f"ASR 转写超时（{self.timeout:g} 秒）") from exc
+        except httpx.RequestError as exc:
+            raise QwenASRError(f"ASR 请求失败: {exc}") from exc
+        if response.status_code >= 400:
+            raise QwenASRError(_response_error(response))
+        return response
+
+    @staticmethod
+    def _parse_result(payload: object, *, model: str | None = None) -> ASRResult:
+        if not isinstance(payload, dict):
+            raise QwenASRError("ASR 响应中的转写结果不是 JSON 对象")
+        text = payload.get("text")
+        if not isinstance(text, str):
+            raise QwenASRError("ASR 响应缺少字符串字段 text")
+        return ASRResult(
+            text=text.strip(),
+            language=_optional_text(payload, "language"),
+            model=_optional_text(payload, "model") or model,
+            emotion=_optional_text(payload, "emotion", "emotion_label"),
+        )
+
+    def _transcribe_one(self, path: str) -> ASRResult:
+        with open(path, "rb") as handle:
+            response = self._request(
+                _SINGLE_PATH,
+                files={"file": self._file_tuple(path, handle)},
+                data=self._form_data(),
+            )
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise QwenASRError("ASR 单文件接口未返回 JSON") from exc
+        return self._parse_result(payload)
+
+    def _transcribe_batch(self, paths: list[str]) -> dict[str, ASRResult]:
+        with ExitStack() as stack:
+            multipart = [
+                ("files", self._file_tuple(path, stack.enter_context(open(path, "rb"))))
+                for path in paths
+            ]
+            response = self._request(_BATCH_PATH, files=multipart, data=self._form_data())
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise QwenASRError("ASR 批量接口未返回 JSON") from exc
+        if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
+            raise QwenASRError("ASR 批量响应缺少 results 数组")
+
+        model = _optional_text(payload, "model")
+        indexed: dict[int, dict] = {}
+        for item in payload["results"]:
+            if not isinstance(item, dict) or not isinstance(item.get("index"), int):
+                raise QwenASRError("ASR 批量响应包含无效的 index")
+            indexed[item["index"]] = item
+        if set(indexed) != set(range(len(paths))):
+            raise QwenASRError("ASR 批量响应数量或顺序不完整")
+
+        return {
+            path: self._parse_result(indexed[index], model=model)
+            for index, path in enumerate(paths)
+        }

--- a/extractor/exporter.py
+++ b/extractor/exporter.py
@@ -8,7 +8,14 @@ import re
 import time
 import urllib.parse
 
+from common import paths
+from extractor.asr import ASRResult, QwenASRClient
 from extractor.models import get_db
+from extractor.voice_recognition import (
+    ensure_transcription_table,
+    load_cached_transcription,
+    save_cached_transcription,
+)
 
 # DB msg_type → ChatLab message type
 CHATLAB_TYPE_MAP = {
@@ -209,7 +216,72 @@ def _get_content_json(msg) -> dict | None:
     return None
 
 
-def _resolve_message(msg, cj: dict | None, media_dir: str) -> tuple:
+def _is_voice_message(cj: dict | None) -> bool:
+    """Return whether a content_json object represents a Douyin voice message."""
+    return bool(cj and cj.get("resource_url") and cj.get("duration"))
+
+
+def _voice_label(cj: dict | None) -> str:
+    try:
+        dur_sec = round(float((cj or {}).get("duration") or 0) / 1000)
+    except (TypeError, ValueError):
+        dur_sec = 0
+    return f"[语音 {dur_sec}秒]" if dur_sec else "[语音]"
+
+
+def _voice_content(cj: dict | None, transcription: ASRResult | None) -> str:
+    """Combine the stable voice label with an optional ASR result."""
+    if not transcription or not transcription.text.strip():
+        return _voice_label(cj)
+    emotion = (
+        f"[情绪: {transcription.emotion}] " if transcription.emotion else ""
+    )
+    return f"[语音转文本] {emotion}{transcription.text.strip()}"
+
+
+def _local_media_path(media_dir: str, stored_path: str | None) -> str | None:
+    """Resolve a DB media path written on either Windows or POSIX."""
+    if not stored_path:
+        return None
+    value = os.fspath(stored_path)
+    if os.path.isabs(value):
+        return value if os.path.isfile(value) else None
+    relative = value.replace("\\", os.sep).replace("/", os.sep)
+    candidate = os.path.abspath(os.path.join(media_dir, relative))
+    return candidate if os.path.isfile(candidate) else None
+
+
+def _voice_audio_path(msg, cj: dict | None, media_dir: str) -> str | None:
+    """Find the local audio downloaded by ``WebChatScraper``.
+
+    New rows carry ``media_local_path=voice/<server id>.mpeg``.  The filename
+    fallback also supports older databases where the audio exists but that
+    column was not populated.
+    """
+    stored = _local_media_path(media_dir, msg["media_local_path"])
+    if stored:
+        return stored
+    if not _is_voice_message(cj):
+        return None
+
+    msg_id = str(msg["msg_id"] or "")
+    stem = msg_id[4:] if msg_id.startswith("srv_") else msg_id
+    if not stem:
+        return None
+    voice_dir = os.path.join(media_dir, "voice")
+    for ext in (".mpeg", ".mp3", ".wav", ".m4a", ".mp4", ".aac", ".ogg", ".flac", ".webm"):
+        candidate = os.path.join(voice_dir, stem + ext)
+        if os.path.isfile(candidate):
+            return os.path.abspath(candidate)
+    return None
+
+
+def _resolve_message(
+    msg,
+    cj: dict | None,
+    media_dir: str,
+    voice_transcription: ASRResult | None = None,
+) -> tuple:
     """Decide the ChatLab content + type for one DB message.
 
     Returns (content, chatlab_type, stats) where stats is a dict of counter
@@ -222,15 +294,18 @@ def _resolve_message(msg, cj: dict | None, media_dir: str) -> tuple:
     chatlab_type = CHATLAB_TYPE_MAP.get(msg_type, 99)
     stats: dict = {}
 
-    # 语音消息：msg_type=0 但有 resource_url + duration
-    # 不再嵌 base64 / CDN URL —— 对 LLM 无意义且每条几百 KB；用纯文字标签即可。
+    # 语音消息：msg_type=0 但有 resource_url + duration。音频本身不嵌入
+    # ChatLab；启用 ASR 时在稳定标签后附上转写，失败仍保留原标签。
     is_voice = False
-    if cj and cj.get("resource_url") and cj.get("duration"):
+    if _is_voice_message(cj):
         is_voice = True
         chatlab_type = 0  # TEXT
-        dur_sec = round(cj["duration"] / 1000)
-        content = f"[语音 {dur_sec}秒]" if dur_sec else "[语音]"
+        content = _voice_content(cj, voice_transcription)
         stats["voice"] = 1
+        if voice_transcription and voice_transcription.text.strip():
+            stats["voice_transcribed"] = 1
+        if voice_transcription and voice_transcription.emotion:
+            stats["voice_emotion"] = 1
 
     # 视频消息：msg_type=5 (新分类) 或 cj.video.vid 兜底（老数据）
     is_video = False
@@ -253,18 +328,16 @@ def _resolve_message(msg, cj: dict | None, media_dir: str) -> tuple:
         if msg["media_url"]:
             content = msg["media_url"]
             stats["image"] = 1
-        elif msg["media_local_path"] and os.path.isfile(
-            os.path.join(media_dir, msg["media_local_path"])
-        ):
-            data_url = _file_to_data_url(
-                os.path.join(media_dir, msg["media_local_path"])
-            )
+        else:
+            local_path = _local_media_path(media_dir, msg["media_local_path"])
+            data_url = _file_to_data_url(local_path) if local_path else None
             if data_url:
                 content = data_url
                 stats["image_embedded"] = 1
-            else:
+            elif local_path:
                 chatlab_type = 0
-            stats["image"] = 1
+            if local_path:
+                stats["image"] = 1
 
     # 分享消息：以 cj 的形态判断（含 itemId），不依赖 msg_type。
     # 不要放宽到 aweType / content_title 等字段 —— 表情消息的 cj 也带这些。
@@ -314,10 +387,158 @@ def _build_reply_to(ref_msg_raw) -> dict | None:
         return None
 
 
+def _positive_number(value, default, cast, label):
+    """Parse a positive CLI/environment number with a safe default."""
+    if value is None or str(value).strip() == "":
+        return default
+    try:
+        parsed = cast(value)
+    except (TypeError, ValueError):
+        print(f"[!] {label}={value!r} 无效，使用默认值 {default}")
+        return default
+    if parsed <= 0:
+        print(f"[!] {label} 必须大于 0，使用默认值 {default}")
+        return default
+    return parsed
+
+
 class ChatLabExporter:
-    def __init__(self, conv_name: str = None, output_format: str = "jsonl"):
+    def __init__(
+        self,
+        conv_name: str = None,
+        output_format: str = "jsonl",
+        *,
+        asr_url: str | None = None,
+        asr_language: str | None = None,
+        asr_prompt: str | None = None,
+        asr_timeout: float | None = None,
+        asr_batch_size: int | None = None,
+    ):
         self.conv_name = conv_name
         self.output_format = output_format  # "json" or "jsonl"
+        # Explicit empty URL disables ASR even when the environment has a URL.
+        self.asr_url = (
+            os.environ.get("QWEN_ASR_URL", "") if asr_url is None else asr_url
+        ).strip()
+        self.asr_language = (
+            os.environ.get("QWEN_ASR_LANGUAGE", "Chinese")
+            if asr_language is None
+            else asr_language
+        ).strip() or None
+        self.asr_prompt = (
+            os.environ.get("QWEN_ASR_PROMPT", "")
+            if asr_prompt is None
+            else asr_prompt
+        ).strip()
+        self.asr_timeout = _positive_number(
+            os.environ.get("QWEN_ASR_TIMEOUT") if asr_timeout is None else asr_timeout,
+            300.0,
+            float,
+            "QWEN_ASR_TIMEOUT",
+        )
+        self.asr_batch_size = _positive_number(
+            os.environ.get("QWEN_ASR_BATCH_SIZE")
+            if asr_batch_size is None
+            else asr_batch_size,
+            10,
+            int,
+            "QWEN_ASR_BATCH_SIZE",
+        )
+        self.last_stats: dict = {}
+
+    def _transcribe_voice_messages(
+        self, message_contexts: list[tuple], media_dir: str
+    ) -> tuple[dict[str, ASRResult], dict]:
+        stats = {
+            "enabled": bool(self.asr_url),
+            "voice_messages": 0,
+            "local_audio": 0,
+            "cached": 0,
+            "transcribed": 0,
+            "empty": 0,
+            "failed": 0,
+            "missing": 0,
+        }
+        by_message_id: dict[str, ASRResult] = {}
+        file_to_messages: dict[str, list[str]] = {}
+        cache_conn = get_db()
+        ensure_transcription_table(cache_conn)
+        try:
+            for msg, cj in message_contexts:
+                if not _is_voice_message(cj):
+                    continue
+                stats["voice_messages"] += 1
+                msg_id = str(msg["msg_id"])
+                audio_path = _voice_audio_path(msg, cj, media_dir)
+                cached = load_cached_transcription(cache_conn, msg_id, audio_path)
+                if cached:
+                    by_message_id[msg_id] = cached
+                    stats["cached"] += 1
+                    continue
+                if not self.asr_url:
+                    continue
+                if not audio_path:
+                    stats["missing"] += 1
+                    continue
+                normalized = os.path.abspath(audio_path)
+                file_to_messages.setdefault(normalized, []).append(msg_id)
+                stats["local_audio"] += 1
+
+            if not self.asr_url:
+                return by_message_id, stats
+
+            if not file_to_messages:
+                if stats["voice_messages"] and not stats["cached"]:
+                    print("[!] 已启用语音转写，但没有找到本地语音文件")
+                return by_message_id, stats
+
+            print(
+                f"[*] Qwen3-ASR: 正在转写 {len(file_to_messages)} 个本地语音文件 "
+                f"({self.asr_url})"
+            )
+            try:
+                with QwenASRClient(
+                    self.asr_url,
+                    language=self.asr_language,
+                    prompt=self.asr_prompt,
+                    timeout=self.asr_timeout,
+                    batch_size=self.asr_batch_size,
+                ) as client:
+                    results, errors = client.transcribe_files(file_to_messages)
+            except Exception as exc:
+                # ASR is an optional enrichment. Preserve a usable export if its
+                # URL/config/client fails unexpectedly.
+                message = f"ASR 初始化失败: {exc}"
+                errors = {path: message for path in file_to_messages}
+                results = {}
+
+            for path, message_ids in file_to_messages.items():
+                result = results.get(path)
+                if result and result.text.strip():
+                    for msg_id in message_ids:
+                        by_message_id[msg_id] = result
+                        save_cached_transcription(
+                            cache_conn, msg_id, result, path, self.asr_url
+                        )
+                    cache_conn.commit()
+                    stats["transcribed"] += len(message_ids)
+                elif result:
+                    stats["empty"] += len(message_ids)
+                else:
+                    stats["failed"] += len(message_ids)
+
+            # Log unique file failures, capped so a dead server cannot flood a
+            # control-panel log for a large conversation.
+            for index, (path, reason) in enumerate(errors.items()):
+                if index >= 10:
+                    print(f"  [ASR] 另有 {len(errors) - 10} 个失败未逐条显示")
+                    break
+                print(f"  [ASR] {os.path.basename(path)} 转写失败: {reason}")
+
+            return by_message_id, stats
+        finally:
+            cache_conn.commit()
+            cache_conn.close()
 
     def export(self, output_path: str):
         conn = get_db()
@@ -371,8 +592,15 @@ class ChatLabExporter:
                     name = owner_name if uid == owner_uid else conv_name
                 members_map[uid] = name
 
-        # Media base dir
-        media_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "media")
+        # Media base dir + content_json are resolved once.  Closing the DB
+        # before a potentially long remote ASR call avoids holding a reader
+        # connection for the duration of model inference.
+        media_dir = paths.MEDIA_DIR
+        message_contexts = [(msg, _get_content_json(msg)) for msg in messages]
+        conn.close()
+        voice_transcriptions, asr_stats = self._transcribe_voice_messages(
+            message_contexts, media_dir
+        )
 
         # Build ChatLab structure
         header = {
@@ -399,13 +627,14 @@ class ChatLabExporter:
         image_embedded = 0
         emoji_count = 0
         voice_count = 0
+        voice_transcribed = 0
+        voice_emotion = 0
         video_count = 0
         system_count = 0
         share_normalized = 0
         ref_count = 0
 
-        for msg in messages:
-            cj = _get_content_json(msg)
+        for msg, cj in message_contexts:
 
             # 发送方：从 users_map 获取昵称
             uid = msg["sender_uid"] or ""
@@ -413,8 +642,15 @@ class ChatLabExporter:
             if not display_name:
                 display_name = owner_name if uid == owner_uid else conv_name
 
-            content, chatlab_type, stats = _resolve_message(msg, cj, media_dir)
+            content, chatlab_type, stats = _resolve_message(
+                msg,
+                cj,
+                media_dir,
+                voice_transcriptions.get(str(msg["msg_id"])),
+            )
             voice_count += stats.get("voice", 0)
+            voice_transcribed += stats.get("voice_transcribed", 0)
+            voice_emotion += stats.get("voice_emotion", 0)
             video_count += stats.get("video", 0)
             emoji_count += stats.get("emoji", 0)
             image_count += stats.get("image", 0)
@@ -438,8 +674,6 @@ class ChatLabExporter:
                 ref_count += 1
 
             chatlab_messages.append(chatlab_msg)
-
-        conn.close()
 
         # Write output
         os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
@@ -472,7 +706,23 @@ class ChatLabExporter:
         if emoji_count:
             print(f"  表情: {emoji_count} (转为文字标签)")
         if voice_count:
-            print(f"  语音: {voice_count} (转为文字标签)")
+            if asr_stats["enabled"] or asr_stats["cached"]:
+                details = [f"已识别 {voice_transcribed}"]
+                if asr_stats["cached"]:
+                    details.append(f"复用缓存 {asr_stats['cached']}")
+                if asr_stats["transcribed"]:
+                    details.append(f"本次识别 {asr_stats['transcribed']}")
+                if asr_stats["empty"]:
+                    details.append(f"空结果 {asr_stats['empty']}")
+                if asr_stats["failed"]:
+                    details.append(f"失败 {asr_stats['failed']}")
+                if asr_stats["missing"]:
+                    details.append(f"缺少本地文件 {asr_stats['missing']}")
+                if voice_emotion:
+                    details.append(f"含情绪 {voice_emotion}")
+                print(f"  语音: {voice_count} ({', '.join(details)})")
+            else:
+                print(f"  语音: {voice_count} (未启用 ASR，转为文字标签)")
         if video_count:
             print(f"  视频: {video_count} (转为文字标签 + 封面图)")
         if system_count:
@@ -483,3 +733,10 @@ class ChatLabExporter:
             print(f"  引用/回复: {ref_count}")
         size_mb = os.path.getsize(output_path) / (1024 * 1024)
         print(f"  文件大小: {size_mb:.1f} MB")
+        self.last_stats = {
+            "messages": len(chatlab_messages),
+            "voice": voice_count,
+            "voice_transcribed": voice_transcribed,
+            "voice_emotion": voice_emotion,
+            "asr": asr_stats,
+        }

--- a/extractor/voice_recognition.py
+++ b/extractor/voice_recognition.py
@@ -1,0 +1,302 @@
+"""Persistent voice-message recognition shared by export and the panel job."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Callable, Iterable
+
+from common import paths
+from extractor.asr import ASRResult, QwenASRClient
+from extractor.models import get_db
+
+
+def ensure_transcription_table(conn) -> None:
+    """Create the cache table for a hot-reloaded process with an older DB."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS voice_transcriptions (
+            msg_id TEXT PRIMARY KEY,
+            text TEXT NOT NULL,
+            language TEXT,
+            model TEXT,
+            emotion TEXT,
+            source_size INTEGER,
+            source_mtime_ns INTEGER,
+            asr_url TEXT,
+            transcribed_at INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+
+
+def get_content_json(msg) -> dict | None:
+    """Extract the complete content_json object from a stored message row."""
+    raw = msg["raw_data"]
+    if not raw:
+        return None
+    try:
+        raw_obj = json.loads(raw) if isinstance(raw, str) else raw
+        cj_raw = raw_obj.get("content_json", "")
+        if cj_raw:
+            return json.loads(cj_raw) if isinstance(cj_raw, str) else cj_raw
+    except (json.JSONDecodeError, KeyError, TypeError):
+        pass
+    return None
+
+
+def is_voice_message(cj: dict | None) -> bool:
+    return bool(cj and cj.get("resource_url") and cj.get("duration"))
+
+
+def local_media_path(media_dir: str, stored_path: str | None) -> str | None:
+    """Resolve a DB media path written on either Windows or POSIX."""
+    if not stored_path:
+        return None
+    value = os.fspath(stored_path)
+    if os.path.isabs(value):
+        return value if os.path.isfile(value) else None
+    relative = value.replace("\\", os.sep).replace("/", os.sep)
+    candidate = os.path.abspath(os.path.join(media_dir, relative))
+    return candidate if os.path.isfile(candidate) else None
+
+
+def voice_audio_path(msg, cj: dict | None, media_dir: str) -> str | None:
+    """Find the local audio downloaded by the scraper, including old rows."""
+    stored = local_media_path(media_dir, msg["media_local_path"])
+    if stored:
+        return stored
+    if not is_voice_message(cj):
+        return None
+
+    msg_id = str(msg["msg_id"] or "")
+    stem = msg_id[4:] if msg_id.startswith("srv_") else msg_id
+    if not stem:
+        return None
+    voice_dir = os.path.join(media_dir, "voice")
+    extensions = (
+        ".mpeg", ".mp3", ".wav", ".m4a", ".mp4",
+        ".aac", ".ogg", ".flac", ".webm",
+    )
+    for ext in extensions:
+        candidate = os.path.join(voice_dir, stem + ext)
+        if os.path.isfile(candidate):
+            return os.path.abspath(candidate)
+    return None
+
+
+def _source_fingerprint(audio_path: str | None) -> tuple[int | None, int | None]:
+    if not audio_path or not os.path.isfile(audio_path):
+        return None, None
+    stat = os.stat(audio_path)
+    return stat.st_size, stat.st_mtime_ns
+
+
+def load_cached_transcription(
+    conn,
+    msg_id: str,
+    audio_path: str | None,
+) -> ASRResult | None:
+    """Load a non-stale cached result for one message."""
+    ensure_transcription_table(conn)
+    row = conn.execute(
+        "SELECT text, language, model, emotion, source_size, source_mtime_ns "
+        "FROM voice_transcriptions WHERE msg_id = ?",
+        (msg_id,),
+    ).fetchone()
+    if not row or not (row["text"] or "").strip():
+        return None
+
+    size, mtime_ns = _source_fingerprint(audio_path)
+    if size is not None:
+        if row["source_size"] is not None and row["source_size"] != size:
+            return None
+        if (
+            row["source_mtime_ns"] is not None
+            and row["source_mtime_ns"] != mtime_ns
+        ):
+            return None
+
+    return ASRResult(
+        text=row["text"].strip(),
+        language=row["language"],
+        model=row["model"],
+        emotion=row["emotion"],
+    )
+
+
+def save_cached_transcription(
+    conn,
+    msg_id: str,
+    result: ASRResult,
+    audio_path: str | None,
+    asr_url: str,
+) -> None:
+    """Upsert one successful non-empty transcription."""
+    if not result.text.strip():
+        return
+    ensure_transcription_table(conn)
+    size, mtime_ns = _source_fingerprint(audio_path)
+    conn.execute(
+        """INSERT INTO voice_transcriptions
+           (msg_id, text, language, model, emotion, source_size,
+            source_mtime_ns, asr_url, transcribed_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(msg_id) DO UPDATE SET
+             text=excluded.text,
+             language=excluded.language,
+             model=excluded.model,
+             emotion=excluded.emotion,
+             source_size=excluded.source_size,
+             source_mtime_ns=excluded.source_mtime_ns,
+             asr_url=excluded.asr_url,
+             transcribed_at=excluded.transcribed_at""",
+        (
+            msg_id,
+            result.text.strip(),
+            result.language,
+            result.model,
+            result.emotion,
+            size,
+            mtime_ns,
+            asr_url,
+            int(time.time()),
+        ),
+    )
+
+
+def _selected_conversation_ids(conn, conversations: Iterable[str] | None) -> list[str]:
+    requested = [str(item).strip() for item in (conversations or []) if str(item).strip()]
+    if not requested:
+        row = conn.execute(
+            "SELECT conv_id FROM conversations ORDER BY last_message_time DESC LIMIT 1"
+        ).fetchone()
+        return [row["conv_id"]] if row else []
+
+    found: list[str] = []
+    for name in requested:
+        row = conn.execute(
+            "SELECT conv_id FROM conversations WHERE name LIKE ? "
+            "ORDER BY last_message_time DESC LIMIT 1",
+            (f"%{name}%",),
+        ).fetchone()
+        if row and row["conv_id"] not in found:
+            found.append(row["conv_id"])
+    return found
+
+
+def recognize_voice_messages(
+    *,
+    conversations: Iterable[str] | None,
+    asr_url: str,
+    language: str | None = "Chinese",
+    prompt: str = "",
+    timeout: float = 300,
+    batch_size: int = 10,
+    force: bool = False,
+    progress_cb: Callable[[dict], None] | None = None,
+) -> dict:
+    """Recognize selected conversations and persist results with progress."""
+    summary = {
+        "total": 0,
+        "done": 0,
+        "ok": 0,
+        "failed": 0,
+        "empty": 0,
+        "missing": 0,
+        "skipped": 0,
+        "current": "",
+        "phase": "scanning",
+    }
+
+    def emit(**changes) -> None:
+        summary.update(changes)
+        if progress_cb:
+            try:
+                progress_cb(dict(summary))
+            except Exception:
+                pass
+
+    conn = get_db()
+    ensure_transcription_table(conn)
+    try:
+        conv_ids = _selected_conversation_ids(conn, conversations)
+        if not conv_ids:
+            emit(phase="completed")
+            return summary
+
+        placeholders = ",".join("?" for _ in conv_ids)
+        rows = conn.execute(
+            f"SELECT * FROM messages WHERE conv_id IN ({placeholders}) ORDER BY seq ASC",
+            tuple(conv_ids),
+        ).fetchall()
+        voices = []
+        for msg in rows:
+            cj = get_content_json(msg)
+            if is_voice_message(cj):
+                voices.append((msg, cj))
+        emit(total=len(voices), phase="scanning")
+
+        file_to_messages: dict[str, list] = {}
+        for msg, cj in voices:
+            msg_id = str(msg["msg_id"])
+            audio_path = voice_audio_path(msg, cj, paths.MEDIA_DIR)
+            current = os.path.basename(audio_path) if audio_path else msg_id
+            if not force and load_cached_transcription(conn, msg_id, audio_path):
+                emit(
+                    done=summary["done"] + 1,
+                    skipped=summary["skipped"] + 1,
+                    current=current,
+                )
+                continue
+            if not audio_path:
+                emit(
+                    done=summary["done"] + 1,
+                    missing=summary["missing"] + 1,
+                    current=current,
+                )
+                continue
+            normalized = os.path.abspath(audio_path)
+            file_to_messages.setdefault(normalized, []).append(msg)
+
+        if not file_to_messages:
+            emit(phase="completed", current="")
+            return summary
+
+        emit(phase="recognizing")
+
+        def on_asr_progress(event: dict) -> None:
+            path = event["path"]
+            linked = file_to_messages.get(path, [])
+            count = len(linked)
+            result = event.get("result")
+            changes = {
+                "done": summary["done"] + count,
+                "current": os.path.basename(path),
+                "phase": "recognizing",
+            }
+            if result and result.text.strip():
+                for msg in linked:
+                    save_cached_transcription(
+                        conn, str(msg["msg_id"]), result, path, asr_url
+                    )
+                conn.commit()
+                changes["ok"] = summary["ok"] + count
+            elif result:
+                changes["empty"] = summary["empty"] + count
+            else:
+                changes["failed"] = summary["failed"] + count
+            emit(**changes)
+
+        with QwenASRClient(
+            asr_url,
+            language=language,
+            prompt=prompt,
+            timeout=timeout,
+            batch_size=min(int(batch_size), 10),
+        ) as client:
+            client.transcribe_files(file_to_messages.keys(), progress_cb=on_asr_progress)
+
+        emit(phase="completed", current="")
+        return summary
+    finally:
+        conn.commit()
+        conn.close()

--- a/tests/baseline/panel.html
+++ b/tests/baseline/panel.html
@@ -131,12 +131,21 @@ body {
 .row + .row { margin-top: 10px; }
 
 /* ── Form controls ── */
-select, input[type=text], input[type=password] {
+select, input[type=text], input[type=password], input[type=number] {
   background: var(--bg3); border: 1px solid var(--border); color: var(--text);
   padding: 8px 12px; border-radius: 9px; font-size: 13px; outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 select:focus, input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-bg); }
+
+.progress-track {
+  height: 9px; margin-top: 12px; overflow: hidden; border-radius: 999px;
+  background: var(--bg3); border: 1px solid var(--border);
+}
+.progress-fill {
+  height: 100%; width: 0; border-radius: inherit; background: var(--accent);
+  transition: width 0.25s ease;
+}
 
 .btn {
   padding: 8px 18px; border: none; border-radius: 9px; font-size: 13px;
@@ -460,6 +469,54 @@ select:focus, input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px v
     <div class="panel-page" id="page-export">
       <div class="page-head"><h1 data-i18n="exportTitle">导出</h1></div>
   <div class="section">
+    <h2><span data-i18n="voiceRecognitionTitle">语音识别</span> <span class="status status-idle" id="voiceRecognitionStatus" data-i18n="idle">闲置</span></h2>
+    <div class="meta" style="margin-bottom:12px" data-i18n="voiceRecognitionDesc">独立识别所选会话的本地语音并保存结果，导出时会直接复用。</div>
+    <div class="row">
+      <input type="text" id="asrUrlInput" data-i18n-placeholder="asrUrlPlaceholder"
+             placeholder="ASR 服务地址，例如 http://127.0.0.1:8000" style="flex:1;min-width:260px;">
+      <select id="asrLanguage">
+        <option value="Chinese" data-i18n="asrLanguageChinese">中文</option>
+        <option value="" data-i18n="asrLanguageAuto">自动检测语言</option>
+        <option value="English">English</option>
+        <option value="Cantonese">Cantonese</option>
+      </select>
+    </div>
+    <div class="row" style="margin-top:10px;">
+      <input type="text" id="asrPromptInput" data-i18n-placeholder="asrPromptPlaceholder"
+             placeholder="可选：输入人名、专有词等识别提示" style="flex:1;min-width:300px;">
+    </div>
+    <div class="row" style="margin-top:10px;">
+      <label class="conv-check" style="cursor:pointer;padding-left:0;">
+        <input type="checkbox" id="asrUseBatchToggle" onchange="toggleAsrBatchFields()" checked>
+        <span data-i18n="asrUseBatch">使用批量接口</span>
+      </label>
+      <label class="row" style="gap:6px;">
+        <span class="meta" style="margin:0" data-i18n="asrBatchSize">每批数量</span>
+        <input type="number" id="asrBatchSizeInput" value="10" min="2" max="10" step="1" style="width:72px;">
+        <span class="meta" style="margin:0" data-i18n="asrBatchUnit">条（最多 10）</span>
+      </label>
+      <label class="conv-check" style="cursor:pointer;">
+        <input type="checkbox" id="forceRecognitionToggle">
+        <span data-i18n="forceRecognition">重新识别已有结果</span>
+      </label>
+      <button class="btn btn-primary" id="voiceRecognitionBtn" onclick="startVoiceRecognition()" data-i18n="voiceRecognitionBtn">开始识别</button>
+    </div>
+    <div class="conv-list-toolbar" style="margin-top:12px;">
+      <span data-i18n="selectConvsLabel">选择会话:</span>
+      <a href="#" onclick="selectAllConvs('recognition',true);return false;" data-i18n="selectAll">全选</a>
+      <span class="sep">·</span>
+      <a href="#" onclick="selectAllConvs('recognition',false);return false;" data-i18n="selectNone">清空</a>
+      <span class="sep">·</span>
+      <span id="recognitionConvCount">0 / 0</span>
+    </div>
+    <div class="conv-list-box" id="recognitionConvList"></div>
+    <div class="progress-track" id="voiceRecognitionProgressTrack" style="display:none;">
+      <div class="progress-fill" id="voiceRecognitionProgress"></div>
+    </div>
+    <div class="meta" id="voiceRecognitionProgressText"></div>
+    <div class="meta" id="voiceRecognitionMsg"></div>
+  </div>
+  <div class="section">
     <h2><span data-i18n="exportTitle">导出</span> <span class="status status-idle" id="exportStatus" data-i18n="idle">闲置</span></h2>
     <div class="row">
       <select id="exportFormat">
@@ -469,6 +526,13 @@ select:focus, input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px v
       <button class="btn btn-primary" id="exportBtn" onclick="startExport()" data-i18n="exportBtn">导出</button>
       <a class="btn btn-success" id="downloadBtn" style="display:none;text-decoration:none" href="/panel/api/export/download" data-i18n="download">下载</a>
     </div>
+    <div class="row" style="margin-top:12px;">
+      <label class="conv-check" style="cursor:pointer;padding-left:0;">
+        <input type="checkbox" id="transcribeVoiceToggle">
+        <span data-i18n="transcribeVoice">导出时识别尚未缓存的语音</span>
+      </label>
+    </div>
+    <div class="meta" data-i18n="asrDesc">已保存的识别结果始终会写入导出；开启此项后只补识别尚未缓存的语音。</div>
     <div class="conv-list-toolbar" style="margin-top:10px;">
       <span data-i18n="selectConvsLabel">选择会话:</span>
       <a href="#" onclick="selectAllConvs('export',true);return false;" data-i18n="selectAll">全选</a>
@@ -595,7 +659,7 @@ const T = {
     typeAndEnter: '输入文字后回车发送...',
     convListTitle: '会话列表',
     refreshConvList: '刷新会话列表',
-    convListHint: '点击"刷新会话列表"从抖音加载全部会话，然后在下方采集/导出/定时各节勾选需要处理的会话。',
+    convListHint: '点击"刷新会话列表"从抖音加载全部会话，然后在下方采集/识别/导出/定时各节勾选需要处理的会话。',
     scraperTitle: '采集',
     incremental: '增量',
     full: '全量',
@@ -614,6 +678,23 @@ const T = {
     exportTitle: '导出',
     exportBtn: '导出',
     download: '下载',
+    voiceRecognitionTitle: '语音识别',
+    voiceRecognitionDesc: '独立识别所选会话的本地语音并保存结果，导出时会直接复用。未选择会话时处理最近会话。',
+    voiceRecognitionBtn: '开始识别',
+    forceRecognition: '重新识别已有结果',
+    asrUseBatch: '使用批量接口',
+    asrBatchSize: '每批数量',
+    asrBatchUnit: '条（最多 10）',
+    transcribeVoice: '导出时识别尚未缓存的语音',
+    asrUrlPlaceholder: 'ASR 服务地址，例如 http://127.0.0.1:8000',
+    asrLanguageChinese: '中文',
+    asrLanguageAuto: '自动检测语言',
+    asrPromptPlaceholder: '可选：输入人名、专有词等识别提示',
+    asrDesc: '已保存的识别结果始终会写入导出；开启此项后只补识别尚未缓存的语音。',
+    asrUrlRequired: '启用语音转写时必须填写 ASR 服务地址',
+    voiceRecognitionProgress: (done, total, ok, fail, missing, skipped, empty) => `进度 ${done} / ${total} · 成功 ${ok} · 失败 ${fail} · 缺文件 ${missing} · 跳过缓存 ${skipped} · 空结果 ${empty}`,
+    voiceRecognitionStartFailed: '启动语音识别失败',
+    exportRequestFailed: '导出请求失败',
     passwordTitle: '密码',
     passwordDesc: '设置密码以保护聊天查看器和控制面板。',
     enterPassword: '输入密码',
@@ -692,7 +773,7 @@ const T = {
     typeAndEnter: 'Type here and press Enter to send...',
     convListTitle: 'Conversations',
     refreshConvList: 'Refresh conversation list',
-    convListHint: 'Click "Refresh conversation list" to load all conversations from Douyin, then check the ones you want in each section below.',
+    convListHint: 'Click "Refresh conversation list" to load all conversations from Douyin, then choose items independently for scrape, recognition, export, and schedule.',
     scraperTitle: 'Scraper',
     incremental: 'Incremental',
     full: 'Full',
@@ -711,6 +792,23 @@ const T = {
     exportTitle: 'Export',
     exportBtn: 'Export',
     download: 'Download',
+    voiceRecognitionTitle: 'Voice Recognition',
+    voiceRecognitionDesc: 'Recognize and save local voice messages for the selected conversations. Exports reuse saved results. With no selection, the latest conversation is used.',
+    voiceRecognitionBtn: 'Start recognition',
+    forceRecognition: 'Re-recognize saved results',
+    asrUseBatch: 'Use batch endpoint',
+    asrBatchSize: 'Batch size',
+    asrBatchUnit: 'items (max 10)',
+    transcribeVoice: 'Recognize uncached voice during export',
+    asrUrlPlaceholder: 'ASR server URL, e.g. http://127.0.0.1:8000',
+    asrLanguageChinese: 'Chinese',
+    asrLanguageAuto: 'Auto-detect language',
+    asrPromptPlaceholder: 'Optional: names and domain terms to recognize',
+    asrDesc: 'Saved results are always exported. Enable this only to recognize voice messages that are not cached yet.',
+    asrUrlRequired: 'Enter an ASR server URL when voice transcription is enabled',
+    voiceRecognitionProgress: (done, total, ok, fail, missing, skipped, empty) => `Progress ${done} / ${total} · ${ok} ok · ${fail} failed · ${missing} missing · ${skipped} cached · ${empty} empty`,
+    voiceRecognitionStartFailed: 'Failed to start voice recognition',
+    exportRequestFailed: 'Export request failed',
     passwordTitle: 'Password',
     passwordDesc: 'Set a password to protect the chat viewer and panel.',
     enterPassword: 'Enter password',
@@ -831,10 +929,12 @@ let discoveredAt = 0;
 let selectedMap = {           // section -> Set of nicknames
   scraper: new Set(),
   export: new Set(),
+  recognition: new Set(),
   schedule: new Set(),
 };
 let lastDiscoverStatus = 'idle';
 let lastDiscoverMsg = '';
+let asrConfigLoaded = false;
 
 async function loadStatus() {
   try {
@@ -867,6 +967,18 @@ async function loadStatus() {
     document.getElementById('exportBtn').disabled = es.status === 'running';
     document.getElementById('exportMsg').textContent = es.message || '';
     document.getElementById('downloadBtn').style.display = (es.status === 'completed' && es.file_path) ? '' : 'none';
+    if (!asrConfigLoaded) {
+      const asr = es.asr || {};
+      document.getElementById('transcribeVoiceToggle').checked = !!asr.enabled;
+      document.getElementById('asrUrlInput').value = asr.url || '';
+      document.getElementById('asrLanguage').value = asr.language ?? 'Chinese';
+      document.getElementById('asrPromptInput').value = asr.prompt || '';
+      document.getElementById('asrUseBatchToggle').checked = asr.use_batch !== false;
+      document.getElementById('asrBatchSizeInput').value = Math.max(2, Math.min(10, Number(asr.batch_size) || 10));
+      asrConfigLoaded = true;
+      toggleAsrBatchFields();
+    }
+    renderVoiceRecognitionStatus(d.voice_recognition || {});
 
     // Schedule status
     const sch = d.scheduler;
@@ -916,6 +1028,7 @@ async function loadSelections() {
     const d = await r.json();
     selectedMap.scraper = new Set(d.scraper || []);
     selectedMap.export = new Set(d.export || []);
+    selectedMap.recognition = new Set(d.recognition || []);
     selectedMap.schedule = new Set(d.schedule || []);
   } catch {}
 }
@@ -946,7 +1059,7 @@ function renderDiscoverMeta() {
 }
 
 function renderAllConvLists() {
-  ['scrape', 'schedule', 'export'].forEach(prefix => renderConvList(prefix));
+  ['scrape', 'schedule', 'recognition', 'export'].forEach(prefix => renderConvList(prefix));
   renderConvCounts();
 }
 
@@ -987,7 +1100,7 @@ function renderConvList(prefix) {
 }
 
 function renderConvCounts() {
-  ['scrape', 'schedule', 'export'].forEach(prefix => {
+  ['scrape', 'schedule', 'recognition', 'export'].forEach(prefix => {
     const el = document.getElementById(prefix + 'ConvCount');
     if (!el) return;
     el.textContent = t('convsCount', selectedMap[sectionKey(prefix)].size, discoveredConvs.length);
@@ -1148,19 +1261,125 @@ async function updateSchedule() {
   loadStatus();
 }
 
+function toggleAsrBatchFields() {
+  document.getElementById('asrBatchSizeInput').disabled = !document.getElementById('asrUseBatchToggle').checked;
+}
+
+function getAsrBatchSize() {
+  const input = document.getElementById('asrBatchSizeInput');
+  const value = Math.max(2, Math.min(10, Number.parseInt(input.value, 10) || 10));
+  input.value = value;
+  return value;
+}
+
+let voiceRecognitionPollTimer = null;
+
+function renderVoiceRecognitionStatus(d) {
+  const status = d.status || 'idle';
+  setStatusEl(document.getElementById('voiceRecognitionStatus'), status);
+  const running = status === 'running';
+  const exportRunning = document.getElementById('exportStatus').classList.contains('status-running');
+  document.getElementById('voiceRecognitionBtn').disabled = running || exportRunning;
+  if (running) document.getElementById('exportBtn').disabled = true;
+  const total = Number(d.total) || 0;
+  const done = Number(d.done) || 0;
+  const showProgress = status !== 'idle' || total > 0;
+  document.getElementById('voiceRecognitionProgressTrack').style.display = showProgress ? '' : 'none';
+  document.getElementById('voiceRecognitionProgress').style.width = (total ? Math.min(100, done * 100 / total) : 0) + '%';
+  setDynText(
+    document.getElementById('voiceRecognitionProgressText'),
+    showProgress ? t('voiceRecognitionProgress', done, total, d.ok || 0, d.failed || 0, d.missing || 0, d.skipped || 0, d.empty || 0) : ''
+  );
+  setDynText(document.getElementById('voiceRecognitionMsg'), d.message || '');
+  if (running && !voiceRecognitionPollTimer) {
+    voiceRecognitionPollTimer = setInterval(pollVoiceRecognition, 1000);
+  } else if (!running && voiceRecognitionPollTimer) {
+    clearInterval(voiceRecognitionPollTimer);
+    voiceRecognitionPollTimer = null;
+  }
+}
+
+async function pollVoiceRecognition() {
+  try {
+    const r = await fetch('/panel/api/voice-recognition/status');
+    const d = await r.json();
+    renderVoiceRecognitionStatus(d);
+  } catch (e) { console.error('Voice recognition status failed:', e); }
+}
+
+async function startVoiceRecognition() {
+  const asr_url = document.getElementById('asrUrlInput').value.trim();
+  if (!asr_url) {
+    setDynText(document.getElementById('voiceRecognitionMsg'), t('asrUrlRequired'));
+    document.getElementById('asrUrlInput').focus();
+    return;
+  }
+  const payload = {
+    conversations: [...selectedMap.recognition],
+    asr_url,
+    asr_language: document.getElementById('asrLanguage').value,
+    asr_prompt: document.getElementById('asrPromptInput').value.trim(),
+    use_batch: document.getElementById('asrUseBatchToggle').checked,
+    batch_size: getAsrBatchSize(),
+    force: document.getElementById('forceRecognitionToggle').checked,
+  };
+  document.getElementById('voiceRecognitionBtn').disabled = true;
+  setStatusEl(document.getElementById('voiceRecognitionStatus'), 'running');
+  try {
+    const r = await fetch('/panel/api/voice-recognition', {
+      method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload),
+    });
+    const d = await r.json();
+    if (!r.ok || d.error) throw new Error(d.error || t('voiceRecognitionStartFailed'));
+    await pollVoiceRecognition();
+  } catch (e) {
+    setStatusEl(document.getElementById('voiceRecognitionStatus'), 'failed');
+    setDynText(document.getElementById('voiceRecognitionMsg'), t('voiceRecognitionStartFailed') + ': ' + e.message);
+    document.getElementById('voiceRecognitionBtn').disabled = false;
+  }
+}
+
 async function startExport() {
   const format = document.getElementById('exportFormat').value;
   const conversations = [...selectedMap.export];
+  const transcribe_voice = document.getElementById('transcribeVoiceToggle').checked;
+  const asr_url = document.getElementById('asrUrlInput').value.trim();
+  const asr_language = document.getElementById('asrLanguage').value;
+  const asr_prompt = document.getElementById('asrPromptInput').value.trim();
+  const asr_use_batch = document.getElementById('asrUseBatchToggle').checked;
+  const asr_batch_size = getAsrBatchSize();
+  if (transcribe_voice && !asr_url) {
+    document.getElementById('exportMsg').textContent = t('asrUrlRequired');
+    document.getElementById('asrUrlInput').focus();
+    return;
+  }
   if (conversations.length > 1 && !confirm(t('confirmMultiExport', conversations.length))) {
     return;
   }
   document.getElementById('exportBtn').disabled = true;
   setStatusEl(document.getElementById('exportStatus'), 'running');
-  await fetch('/panel/api/export', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({ format, conversations }),
-  });
+  try {
+    const r = await fetch('/panel/api/export', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        format, conversations, transcribe_voice, asr_url, asr_language, asr_prompt,
+        asr_use_batch, asr_batch_size,
+      }),
+    });
+    const d = await r.json();
+    if (!r.ok || d.error) {
+      setStatusEl(document.getElementById('exportStatus'), 'failed');
+      document.getElementById('exportMsg').textContent = d.error || t('exportRequestFailed');
+      document.getElementById('exportBtn').disabled = false;
+      return;
+    }
+  } catch (e) {
+    setStatusEl(document.getElementById('exportStatus'), 'failed');
+    document.getElementById('exportMsg').textContent = t('exportRequestFailed') + ': ' + e;
+    document.getElementById('exportBtn').disabled = false;
+    return;
+  }
   loadStatus();
 }
 
@@ -1544,6 +1763,7 @@ async function panelAuthCheck() {
       loadPasswordStatus();
       loadNotifyStatus();
       loadDownloadImages();
+      pollVoiceRecognition();
       pollBackfill();
       loadVideoPending();
       pollVideoBackfill();

--- a/tests/baseline/routes.json
+++ b/tests/baseline/routes.json
@@ -28,6 +28,7 @@
  "GET /panel/api/password/status",
  "GET /panel/api/scrape/log",
  "GET /panel/api/status",
+ "GET /panel/api/voice-recognition/status",
  "GET /{full_path}",
  "POST /api/auth/login",
  "POST /api/conversations/{conv_id}/delete",
@@ -50,5 +51,6 @@
  "POST /panel/api/password",
  "POST /panel/api/schedule",
  "POST /panel/api/scrape",
- "POST /panel/api/scrape/stop"
+ "POST /panel/api/scrape/stop",
+ "POST /panel/api/voice-recognition"
 ]

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -1,0 +1,180 @@
+"""Contract tests for the Qwen3-ASR HTTP client."""
+import os
+
+import httpx
+
+from extractor.asr import ASRResult, QwenASRClient, normalize_server_url
+
+
+def test_normalize_server_url_accepts_base_or_full_endpoint():
+    assert normalize_server_url("http://asr:8000/") == "http://asr:8000"
+    assert normalize_server_url(
+        "https://example.test/prefix/v1/audio/transcriptions/batch"
+    ) == "https://example.test/prefix"
+
+
+def test_batch_transcription_contract_and_optional_emotion(tmp_path):
+    first = tmp_path / "a.wav"
+    second = tmp_path / "b.wav"
+    first.write_bytes(b"wav-a")
+    second.write_bytes(b"wav-b")
+    seen_body = b""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal seen_body
+        if request.url.path == "/prefix/healthz":
+            return httpx.Response(200, json={"ok": True})
+        assert request.url.path == "/prefix/v1/audio/transcriptions/batch"
+        assert request.headers["content-type"].startswith("multipart/form-data")
+        seen_body = request.read()
+        return httpx.Response(
+            200,
+            json={
+                "model": "Qwen/Qwen3-ASR-1.7B-hf",
+                "results": [
+                    {"index": 0, "text": "第一条", "language": "Chinese"},
+                    {
+                        "index": 1,
+                        "text": "第二条",
+                        "language": "Chinese",
+                        "emotion": "happy",
+                    },
+                ],
+            },
+        )
+
+    with QwenASRClient(
+        "http://asr.test/prefix",
+        language="Chinese",
+        prompt="专有名词",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        results, errors = client.transcribe_files([str(first), str(second)])
+
+    assert errors == {}
+    assert results[os.path.abspath(first)] == ASRResult(
+        text="第一条", language="Chinese", model="Qwen/Qwen3-ASR-1.7B-hf"
+    )
+    assert results[os.path.abspath(second)].emotion == "happy"
+    assert b'a.wav' in seen_body and b'b.wav' in seen_body
+    assert "Chinese".encode() in seen_body and "专有名词".encode() in seen_body
+    assert b'convert_audio' in seen_body and b'true' in seen_body
+
+
+def test_failed_batch_falls_back_to_single_file_requests(tmp_path):
+    files = [tmp_path / "a.wav", tmp_path / "b.wav"]
+    for path in files:
+        path.write_bytes(b"audio")
+    single_calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal single_calls
+        if request.url.path == "/healthz":
+            return httpx.Response(200, json={"ok": True})
+        if request.url.path.endswith("/batch"):
+            return httpx.Response(400, json={"detail": "one file is invalid"})
+        single_calls += 1
+        return httpx.Response(
+            200,
+            json={"text": f"文本{single_calls}", "language": "Chinese"},
+        )
+
+    with QwenASRClient(
+        "http://asr.test", transport=httpx.MockTransport(handler)
+    ) as client:
+        results, errors = client.transcribe_files(files)
+
+    assert errors == {}
+    assert single_calls == 2
+    assert [results[os.path.abspath(path)].text for path in files] == ["文本1", "文本2"]
+
+
+def test_one_file_uses_single_endpoint_without_batch(tmp_path):
+    audio = tmp_path / "one.mpeg"
+    audio.write_bytes(b"audio")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/healthz":
+            return httpx.Response(200, json={"ok": True})
+        assert request.url.path == "/v1/audio/transcriptions"
+        return httpx.Response(200, json={"text": "单文件", "language": "Chinese"})
+
+    with QwenASRClient(
+        "http://asr.test", transport=httpx.MockTransport(handler)
+    ) as client:
+        results, errors = client.transcribe_files([audio])
+
+    assert errors == {}
+    assert results[os.path.abspath(audio)].text == "单文件"
+
+
+def test_health_failure_is_reported_for_every_file(tmp_path):
+    audio = tmp_path / "voice.mpeg"
+    audio.write_bytes(b"audio")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"detail": "Model is not ready yet."})
+
+    with QwenASRClient(
+        "http://asr.test", transport=httpx.MockTransport(handler)
+    ) as client:
+        results, errors = client.transcribe_files([audio])
+
+    assert results == {}
+    assert "HTTP 503" in errors[os.path.abspath(audio)]
+    assert "Model is not ready yet" in errors[os.path.abspath(audio)]
+
+
+def test_missing_file_does_not_contact_server(tmp_path):
+    missing = tmp_path / "missing.mpeg"
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
+        raise AssertionError("HTTP must not be called for missing files")
+
+    with QwenASRClient(
+        "http://asr.test", transport=httpx.MockTransport(handler)
+    ) as client:
+        results, errors = client.transcribe_files([missing])
+
+    assert results == {}
+    assert errors[os.path.abspath(missing)] == "本地语音文件不存在"
+
+
+def test_batch_size_is_capped_at_ten_and_reports_progress(tmp_path):
+    files = []
+    for index in range(23):
+        path = tmp_path / f"{index}.wav"
+        path.write_bytes(b"audio")
+        files.append(path)
+    batch_sizes = []
+    progress = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/healthz":
+            return httpx.Response(200, json={"ok": True})
+        body = request.read()
+        count = body.count(b'name="files"')
+        batch_sizes.append(count)
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"index": index, "text": f"文本{index}"}
+                    for index in range(count)
+                ]
+            },
+        )
+
+    with QwenASRClient(
+        "http://asr.test",
+        batch_size=99,
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        results, errors = client.transcribe_files(files, progress_cb=progress.append)
+
+    assert errors == {}
+    assert len(results) == 23
+    assert batch_sizes == [10, 10, 3]
+    assert len(progress) == 23
+    assert progress[-1]["done"] == 23
+    assert progress[-1]["total"] == 23

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -82,6 +82,16 @@ def test_search_joins_conv_and_sender_name(temp_db):
 def test_delete_conversation_removes_messages(temp_db):
     import backend.database as database
     _seed(temp_db)
+    conn = database.get_db()
+    conn.execute(
+        "INSERT INTO voice_transcriptions (msg_id, text, transcribed_at) "
+        "VALUES ('m1', '识别文本', 1)"
+    )
+    conn.commit()
+    conn.close()
     res = database.delete_conversation("c1")
     assert res == {"conversation_deleted": 1, "messages_deleted": 5}
     assert database.get_conversation("c1") is None
+    conn = database.get_db()
+    assert conn.execute("SELECT COUNT(*) FROM voice_transcriptions").fetchone()[0] == 0
+    conn.close()

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -4,8 +4,10 @@ Locks the exact output strings/types the exporter produces, so the P4 refactor
 (splitting the 240-line export() god-method into pure functions) cannot drift.
 """
 import json
+import os
 
 from extractor import exporter
+from extractor.asr import ASRResult
 from extractor.exporter import (
     ChatLabExporter,
     _build_reply_to,
@@ -35,6 +37,17 @@ def test_resolve_voice_beats_everything():
     cj = {"resource_url": "x", "duration": 2500}
     content, ctype, stats = _resolve_message(_msg(msg_type=0), cj, "/tmp")
     assert content == "[语音 2秒]" and ctype == 0 and stats == {"voice": 1}
+
+
+def test_resolve_voice_with_transcription_and_future_emotion():
+    cj = {"resource_url": "x", "duration": 2500}
+    result = ASRResult(text="今天心情很好", language="Chinese", emotion="happy")
+    content, ctype, stats = _resolve_message(
+        _msg(msg_type=0), cj, "/tmp", result
+    )
+    assert content == "[语音转文本] [情绪: happy] 今天心情很好"
+    assert ctype == 0
+    assert stats == {"voice": 1, "voice_transcribed": 1, "voice_emotion": 1}
 
 
 def test_resolve_video_type5():
@@ -188,3 +201,67 @@ def test_export_json_format_shape(temp_db, tmp_path):
     assert data["chatlab"]["version"] == "0.0.2"
     assert isinstance(data["members"], list)
     assert data["messages"][0]["content"] == "hi"
+
+
+def test_full_export_transcribes_local_voice(temp_db, tmp_path, monkeypatch):
+    import common.paths as paths
+    import extractor.models as models
+
+    media_dir = tmp_path / "media"
+    voice_dir = media_dir / "voice"
+    voice_dir.mkdir(parents=True)
+    audio = voice_dir / "7659828680696448563.mpeg"
+    audio.write_bytes(b"fake audio sent through mocked client")
+    monkeypatch.setattr(paths, "MEDIA_DIR", str(media_dir))
+
+    conn = models.get_db()
+    insert_conversation(conn, "c1", "语音会话", participant_uids='["owner"]')
+    conn.execute("INSERT INTO users (uid, nickname) VALUES ('owner','我')")
+    voice_cj = {"resource_url": {"url_list": ["https://cdn/voice"]}, "duration": 3100}
+    insert_message(
+        conn,
+        "srv_7659828680696448563",
+        "c1",
+        1,
+        sender_uid="owner",
+        msg_type=0,
+        media_local_path="voice/7659828680696448563.mpeg",
+        raw_data=_raw(voice_cj),
+    )
+    conn.commit()
+    conn.close()
+
+    class FakeASRClient:
+        def __init__(self, server_url, **kwargs):
+            assert server_url == "http://asr.test:8111"
+            assert kwargs["language"] == "Chinese"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def transcribe_files(self, file_paths):
+            file_paths = list(file_paths)
+            assert file_paths == [os.path.abspath(audio)]
+            return {
+                file_paths[0]: ASRResult(
+                    text="这是测试语音。", language="Chinese", model="Qwen3-ASR"
+                )
+            }, {}
+
+    monkeypatch.setattr(exporter, "QwenASRClient", FakeASRClient)
+    out = tmp_path / "voice.json"
+    exp = ChatLabExporter(
+        conv_name="语音会话",
+        output_format="json",
+        asr_url="http://asr.test:8111",
+    )
+    exp.export(str(out))
+
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["messages"][0]["content"] == "[语音转文本] 这是测试语音。"
+    assert exp.last_stats["voice"] == 1
+    assert exp.last_stats["voice_transcribed"] == 1
+    assert exp.last_stats["asr"]["failed"] == 0

--- a/tests/test_panel_export_asr.py
+++ b/tests/test_panel_export_asr.py
@@ -1,0 +1,122 @@
+"""Control-panel contract tests for ASR export settings."""
+import asyncio
+
+import pytest
+
+from backend import control_panel as cp
+
+
+@pytest.fixture(autouse=True)
+def restore_job_states():
+    export_state = dict(cp._export_state)
+    recognition_state = dict(cp._voice_recognition_state)
+    yield
+    cp._export_state.clear()
+    cp._export_state.update(export_state)
+    cp._voice_recognition_state.clear()
+    cp._voice_recognition_state.update(recognition_state)
+
+
+def test_export_rejects_enabled_asr_without_url(monkeypatch):
+    monkeypatch.setitem(cp._export_state, "status", "idle")
+    request = cp.ExportRequest(transcribe_voice=True, asr_url="")
+
+    response = asyncio.run(cp.start_export(request))
+
+    assert response.status_code == 400
+    assert cp._export_state["status"] == "idle"
+
+
+def test_export_persists_and_passes_normalized_asr_settings(monkeypatch):
+    monkeypatch.setitem(cp._export_state, "status", "idle")
+    saved = {}
+    called = {}
+    monkeypatch.setattr(cp, "_load_config", lambda: {"custom_filters": []})
+    monkeypatch.setattr(cp, "_save_config", lambda cfg: saved.update(cfg))
+
+    def fake_export(*args):
+        called["args"] = args
+        cp._export_state["status"] = "completed"
+        cp._export_state["message"] = "ok"
+
+    monkeypatch.setattr(cp, "_do_export", fake_export)
+    request = cp.ExportRequest(
+        format="json",
+        conversations=["测试会话"],
+        transcribe_voice=True,
+        asr_url="http://asr.test:8111/v1/audio/transcriptions",
+        asr_language="Chinese",
+        asr_prompt="人名：小明",
+    )
+
+    response = asyncio.run(cp.start_export(request))
+
+    assert response["status"] == "completed"
+    assert called["args"] == (
+        "json",
+        "",
+        ["测试会话"],
+        "http://asr.test:8111",
+        "Chinese",
+        "人名：小明",
+        10,
+    )
+    assert saved["export_selected"] == ["测试会话"]
+    assert saved["asr_enabled"] is True
+    assert saved["asr_url"] == "http://asr.test:8111"
+    assert saved["asr_language"] == "Chinese"
+    assert saved["asr_prompt"] == "人名：小明"
+    assert saved["asr_use_batch"] is True
+    assert saved["asr_batch_size"] == 10
+
+
+def test_standalone_recognition_starts_background_job_and_clamps_batch(monkeypatch):
+    monkeypatch.setitem(cp._voice_recognition_state, "status", "idle")
+    monkeypatch.setitem(cp._export_state, "status", "idle")
+    saved = {}
+    created = []
+    monkeypatch.setattr(cp, "_load_config", lambda: {})
+    monkeypatch.setattr(cp, "_save_config", lambda cfg: saved.update(cfg))
+
+    def fake_create_task(coro):
+        created.append(coro)
+        coro.close()
+        return "task"
+
+    monkeypatch.setattr(cp.asyncio, "create_task", fake_create_task)
+    request = cp.VoiceRecognitionRequest(
+        conversations=["识别会话"],
+        asr_url="http://asr.test:8111/v1/audio/transcriptions",
+        use_batch=True,
+        batch_size=999,
+    )
+
+    response = asyncio.run(cp.start_voice_recognition(request))
+
+    assert response == {"status": "started"}
+    assert len(created) == 1
+    assert cp._voice_recognition_state["status"] == "running"
+    assert saved["recognition_selected"] == ["识别会话"]
+    assert saved["asr_url"] == "http://asr.test:8111"
+    assert saved["asr_use_batch"] is True
+    assert saved["asr_batch_size"] == 10
+
+
+def test_recognition_progress_state_contains_counts_and_current(monkeypatch):
+    monkeypatch.setitem(cp._voice_recognition_state, "status", "running")
+    cp._update_voice_recognition_progress({
+        "phase": "recognizing",
+        "total": 12,
+        "done": 7,
+        "ok": 5,
+        "failed": 1,
+        "empty": 0,
+        "missing": 1,
+        "skipped": 0,
+        "current": "7659828680696448563.mpeg",
+    })
+
+    state = cp._voice_recognition_payload()
+    assert state["done"] == 7 and state["total"] == 12
+    assert state["ok"] == 5 and state["failed"] == 1 and state["missing"] == 1
+    assert "7659828680696448563.mpeg" in state["message"]

--- a/tests/test_panel_jobs.py
+++ b/tests/test_panel_jobs.py
@@ -72,6 +72,23 @@ def test_backfill_start_conflict(monkeypatch):
     assert getattr(res, "status_code", None) == 409
 
 
+def test_windows_subprocess_output_is_forced_to_utf8(monkeypatch):
+    monkeypatch.setenv("PYTHONIOENCODING", "gbk")
+    env = cp._utf8_subprocess_env()
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    assert env["PYTHONUNBUFFERED"] == "1"
+
+
+def test_log_reader_supports_utf8_and_legacy_gbk(tmp_path):
+    utf8_log = tmp_path / "utf8.log"
+    gbk_log = tmp_path / "gbk.log"
+    utf8_log.write_bytes("正在识别语音".encode("utf-8"))
+    gbk_log.write_bytes("发现 3 个会话".encode("gb18030"))
+    assert cp._read_utf8_or_gbk(str(utf8_log)) == "正在识别语音"
+    assert cp._read_utf8_or_gbk(str(gbk_log)) == "发现 3 个会话"
+
+
 def test_run_scrape_clears_stale_stop_flag_and_reports_failure(isolated_scrape, monkeypatch):
     # Simulate a stale 'stopped' flag left by an earlier manual Stop, then a
     # cron/manual scrape that genuinely fails. It must be reported as failed and

--- a/tests/test_routes_contract.py
+++ b/tests/test_routes_contract.py
@@ -29,6 +29,8 @@ def test_route_surface_unchanged():
 
 def test_panel_html_byte_identical():
     client = TestClient(main.app)
-    body = client.get("/panel").content
+    response = client.get("/panel")
+    body = response.content
     expected = open(os.path.join(_BASELINE, "panel.html"), "rb").read()
     assert body == expected
+    assert "charset=utf-8" in response.headers["content-type"].lower()

--- a/tests/test_voice_recognition.py
+++ b/tests/test_voice_recognition.py
@@ -1,0 +1,137 @@
+"""Persistent standalone voice-recognition workflow tests."""
+import json
+import os
+
+from extractor import voice_recognition as vr
+from extractor.asr import ASRResult
+from extractor.exporter import ChatLabExporter
+from tests.conftest import insert_conversation, insert_message
+
+
+def _raw(cj: dict) -> str:
+    return json.dumps({"content_json": json.dumps(cj)}, ensure_ascii=False)
+
+
+def _seed_voice(temp_db, tmp_path, monkeypatch):
+    import common.paths as paths
+    import extractor.models as models
+
+    media_dir = tmp_path / "media"
+    voice_dir = media_dir / "voice"
+    voice_dir.mkdir(parents=True)
+    audio = voice_dir / "10001.mpeg"
+    audio.write_bytes(b"douyin voice")
+    monkeypatch.setattr(paths, "MEDIA_DIR", str(media_dir))
+
+    conn = models.get_db()
+    insert_conversation(
+        conn, "c1", "识别会话", participant_uids='["owner"]', last_message_time=10
+    )
+    conn.execute("INSERT INTO users (uid, nickname) VALUES ('owner','我')")
+    insert_message(
+        conn,
+        "srv_10001",
+        "c1",
+        1,
+        sender_uid="owner",
+        msg_type=0,
+        media_local_path="voice/10001.mpeg",
+        raw_data=_raw({"resource_url": {"url_list": ["x"]}, "duration": 3000}),
+    )
+    conn.commit()
+    conn.close()
+    return audio
+
+
+def test_standalone_recognition_persists_progress_and_export_reuses_cache(
+    temp_db, tmp_path, monkeypatch
+):
+    audio = _seed_voice(temp_db, tmp_path, monkeypatch)
+    progress = []
+    constructed = []
+
+    class FakeClient:
+        def __init__(self, server_url, **kwargs):
+            constructed.append((server_url, kwargs["batch_size"]))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def transcribe_files(self, paths, progress_cb=None):
+            path = os.path.abspath(list(paths)[0])
+            result = ASRResult(text="这是持久化识别文本。", language="Chinese")
+            if progress_cb:
+                progress_cb({"path": path, "result": result, "error": None,
+                             "done": 1, "total": 1})
+            return {path: result}, {}
+
+    monkeypatch.setattr(vr, "QwenASRClient", FakeClient)
+    result = vr.recognize_voice_messages(
+        conversations=["识别会话"],
+        asr_url="http://asr.test:8111",
+        batch_size=50,
+        progress_cb=progress.append,
+    )
+
+    assert constructed == [("http://asr.test:8111", 10)]
+    assert result["total"] == 1 and result["done"] == 1 and result["ok"] == 1
+    assert progress[-1]["phase"] == "completed"
+
+    # A second standalone run skips the valid cache without constructing a client.
+    constructed.clear()
+    second = vr.recognize_voice_messages(
+        conversations=["识别会话"], asr_url="http://asr.test:8111"
+    )
+    assert second["skipped"] == 1 and second["done"] == 1
+    assert constructed == []
+
+    # Export reuses the saved result even when "recognize during export" is off.
+    out = tmp_path / "cached.json"
+    exporter = ChatLabExporter(
+        conv_name="识别会话", output_format="json", asr_url=""
+    )
+    exporter.export(str(out))
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["messages"][0]["content"] == "[语音转文本] 这是持久化识别文本。"
+    assert exporter.last_stats["asr"]["cached"] == 1
+
+    # Changing the source invalidates the fingerprint and requires recognition.
+    audio.write_bytes(b"changed voice payload")
+    conn = vr.get_db()
+    assert vr.load_cached_transcription(conn, "srv_10001", str(audio)) is None
+    conn.close()
+
+
+def test_force_recognition_does_not_skip_cache(temp_db, tmp_path, monkeypatch):
+    audio = _seed_voice(temp_db, tmp_path, monkeypatch)
+    conn = vr.get_db()
+    vr.save_cached_transcription(
+        conn, "srv_10001", ASRResult(text="旧文本"), str(audio), "http://old"
+    )
+    conn.commit()
+    conn.close()
+    calls = []
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            calls.append(1)
+
+        def __enter__(self): return self
+        def __exit__(self, *args): pass
+
+        def transcribe_files(self, paths, progress_cb=None):
+            path = os.path.abspath(list(paths)[0])
+            result = ASRResult(text="新文本")
+            progress_cb({"path": path, "result": result, "error": None,
+                         "done": 1, "total": 1})
+            return {path: result}, {}
+
+    monkeypatch.setattr(vr, "QwenASRClient", FakeClient)
+    result = vr.recognize_voice_messages(
+        conversations=["识别会话"], asr_url="http://new", force=True
+    )
+    assert calls == [1]
+    assert result["ok"] == 1 and result["skipped"] == 0


### PR DESCRIPTION
大佬好，我想把聊天记录发给 AI 进行分析，例如隔壁的微信 WeFlow 项目。

因为平时聊天对象语音发的比较多，但是发现本项目没有语音识别功能，所以想着添加一个。

我试了几个 ASR 发现 Qwen3‑ASR-1.7B 识别效果很好。

然后发现这个项目的服务端有完整的教程，且可以 CPU 部署，也不用先上传文件到 OSS https://github.com/MeidoPromotionAssociation/Qwen3-ASR-Custom-Server

因此我用 gpt-5.6-sol max 制作了这个 PR，本人测试效果很好，希望可以合并，谢谢。

具体说明已经补充到了 [ReadMe](https://github.com/TeamBreakerr/douyin-chat-export/pull/27/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)


另外顺便修复了在 Windows 使用时网页的信息框会乱码的问题。